### PR TITLE
feat: notify on warning separation

### DIFF
--- a/app/client/api-client/types.gen.ts
+++ b/app/client/api-client/types.gen.ts
@@ -2034,6 +2034,7 @@ export type GetScheduleNotificationsResponses = {
         notifyOnFailure: boolean;
         notifyOnStart: boolean;
         notifyOnSuccess: boolean;
+        notifyOnWarning: boolean;
         scheduleId: number;
     }>;
 };
@@ -2047,6 +2048,7 @@ export type UpdateScheduleNotificationsData = {
             notifyOnFailure: boolean;
             notifyOnStart: boolean;
             notifyOnSuccess: boolean;
+            notifyOnWarning: boolean;
         }>;
     };
     path: {
@@ -2122,6 +2124,7 @@ export type UpdateScheduleNotificationsResponses = {
         notifyOnFailure: boolean;
         notifyOnStart: boolean;
         notifyOnSuccess: boolean;
+        notifyOnWarning: boolean;
         scheduleId: number;
     }>;
 };

--- a/app/client/modules/backups/components/schedule-notifications-config.tsx
+++ b/app/client/modules/backups/components/schedule-notifications-config.tsx
@@ -24,6 +24,7 @@ type NotificationAssignment = {
 	destinationId: number;
 	notifyOnStart: boolean;
 	notifyOnSuccess: boolean;
+	notifyOnWarning: boolean;
 	notifyOnFailure: boolean;
 };
 
@@ -57,6 +58,7 @@ export const ScheduleNotificationsConfig = ({ scheduleId, destinations }: Props)
 					destinationId: assignment.destinationId,
 					notifyOnStart: assignment.notifyOnStart,
 					notifyOnSuccess: assignment.notifyOnSuccess,
+					notifyOnWarning: assignment.notifyOnWarning,
 					notifyOnFailure: assignment.notifyOnFailure,
 				});
 			}
@@ -72,6 +74,7 @@ export const ScheduleNotificationsConfig = ({ scheduleId, destinations }: Props)
 			destinationId: id,
 			notifyOnStart: false,
 			notifyOnSuccess: false,
+			notifyOnWarning: true,
 			notifyOnFailure: true,
 		});
 
@@ -87,7 +90,10 @@ export const ScheduleNotificationsConfig = ({ scheduleId, destinations }: Props)
 		setHasChanges(true);
 	};
 
-	const toggleEvent = (destinationId: number, event: "notifyOnStart" | "notifyOnSuccess" | "notifyOnFailure") => {
+	const toggleEvent = (
+		destinationId: number,
+		event: "notifyOnStart" | "notifyOnSuccess" | "notifyOnWarning" | "notifyOnFailure",
+	) => {
 		const assignment = assignments.get(destinationId);
 		if (!assignment) return;
 
@@ -119,6 +125,7 @@ export const ScheduleNotificationsConfig = ({ scheduleId, destinations }: Props)
 					destinationId: assignment.destinationId,
 					notifyOnStart: assignment.notifyOnStart,
 					notifyOnSuccess: assignment.notifyOnSuccess,
+					notifyOnWarning: assignment.notifyOnWarning,
 					notifyOnFailure: assignment.notifyOnFailure,
 				});
 			}
@@ -193,7 +200,8 @@ export const ScheduleNotificationsConfig = ({ scheduleId, destinations }: Props)
 									<TableHead>Destination</TableHead>
 									<TableHead className="text-center w-[100px]">Start</TableHead>
 									<TableHead className="text-center w-[100px]">Success</TableHead>
-									<TableHead className="text-center w-[100px]">Failure</TableHead>
+									<TableHead className="text-center w-[100px]">Warnings</TableHead>
+									<TableHead className="text-center w-[100px]">Failures</TableHead>
 									<TableHead className="w-[50px]"></TableHead>
 								</TableRow>
 							</TableHeader>
@@ -224,6 +232,13 @@ export const ScheduleNotificationsConfig = ({ scheduleId, destinations }: Props)
 													className="align-middle"
 													checked={assignment.notifyOnSuccess}
 													onCheckedChange={() => toggleEvent(destination.id, "notifyOnSuccess")}
+												/>
+											</TableCell>
+											<TableCell className="text-center">
+												<Switch
+													className="align-middle"
+													checked={assignment.notifyOnWarning}
+													onCheckedChange={() => toggleEvent(destination.id, "notifyOnWarning")}
 												/>
 											</TableCell>
 											<TableCell className="text-center">

--- a/app/drizzle/0021_steady_viper.sql
+++ b/app/drizzle/0021_steady_viper.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `backup_schedule_notifications_table` ADD `notify_on_warning` integer DEFAULT true NOT NULL;

--- a/app/drizzle/meta/0021_snapshot.json
+++ b/app/drizzle/meta/0021_snapshot.json
@@ -1,0 +1,823 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "e7c02f6c-e255-402e-9f18-d50a3fef8e4d",
+  "prevId": "729d3ce9-b4b9-41f6-a270-d74c96510238",
+  "tables": {
+    "app_metadata": {
+      "name": "app_metadata",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "backup_schedule_mirrors_table": {
+      "name": "backup_schedule_mirrors_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "last_copy_at": {
+          "name": "last_copy_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_copy_status": {
+          "name": "last_copy_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_copy_error": {
+          "name": "last_copy_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "backup_schedule_mirrors_table_schedule_id_repository_id_unique": {
+          "name": "backup_schedule_mirrors_table_schedule_id_repository_id_unique",
+          "columns": [
+            "schedule_id",
+            "repository_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "backup_schedule_mirrors_table_schedule_id_backup_schedules_table_id_fk": {
+          "name": "backup_schedule_mirrors_table_schedule_id_backup_schedules_table_id_fk",
+          "tableFrom": "backup_schedule_mirrors_table",
+          "tableTo": "backup_schedules_table",
+          "columnsFrom": [
+            "schedule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "backup_schedule_mirrors_table_repository_id_repositories_table_id_fk": {
+          "name": "backup_schedule_mirrors_table_repository_id_repositories_table_id_fk",
+          "tableFrom": "backup_schedule_mirrors_table",
+          "tableTo": "repositories_table",
+          "columnsFrom": [
+            "repository_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "backup_schedule_notifications_table": {
+      "name": "backup_schedule_notifications_table",
+      "columns": {
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "destination_id": {
+          "name": "destination_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notify_on_start": {
+          "name": "notify_on_start",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "notify_on_success": {
+          "name": "notify_on_success",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "notify_on_warning": {
+          "name": "notify_on_warning",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "notify_on_failure": {
+          "name": "notify_on_failure",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "backup_schedule_notifications_table_schedule_id_backup_schedules_table_id_fk": {
+          "name": "backup_schedule_notifications_table_schedule_id_backup_schedules_table_id_fk",
+          "tableFrom": "backup_schedule_notifications_table",
+          "tableTo": "backup_schedules_table",
+          "columnsFrom": [
+            "schedule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "backup_schedule_notifications_table_destination_id_notification_destinations_table_id_fk": {
+          "name": "backup_schedule_notifications_table_destination_id_notification_destinations_table_id_fk",
+          "tableFrom": "backup_schedule_notifications_table",
+          "tableTo": "notification_destinations_table",
+          "columnsFrom": [
+            "destination_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "backup_schedule_notifications_table_schedule_id_destination_id_pk": {
+          "columns": [
+            "schedule_id",
+            "destination_id"
+          ],
+          "name": "backup_schedule_notifications_table_schedule_id_destination_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "backup_schedules_table": {
+      "name": "backup_schedules_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "volume_id": {
+          "name": "volume_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "cron_expression": {
+          "name": "cron_expression",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "retention_policy": {
+          "name": "retention_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "exclude_patterns": {
+          "name": "exclude_patterns",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "exclude_if_present": {
+          "name": "exclude_if_present",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "include_patterns": {
+          "name": "include_patterns",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "last_backup_at": {
+          "name": "last_backup_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_backup_status": {
+          "name": "last_backup_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_backup_error": {
+          "name": "last_backup_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "next_backup_at": {
+          "name": "next_backup_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "backup_schedules_table_name_unique": {
+          "name": "backup_schedules_table_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "backup_schedules_table_volume_id_volumes_table_id_fk": {
+          "name": "backup_schedules_table_volume_id_volumes_table_id_fk",
+          "tableFrom": "backup_schedules_table",
+          "tableTo": "volumes_table",
+          "columnsFrom": [
+            "volume_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "backup_schedules_table_repository_id_repositories_table_id_fk": {
+          "name": "backup_schedules_table_repository_id_repositories_table_id_fk",
+          "tableFrom": "backup_schedules_table",
+          "tableTo": "repositories_table",
+          "columnsFrom": [
+            "repository_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notification_destinations_table": {
+      "name": "notification_destinations_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "notification_destinations_table_name_unique": {
+          "name": "notification_destinations_table_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "repositories_table": {
+      "name": "repositories_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "short_id": {
+          "name": "short_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "compression_mode": {
+          "name": "compression_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'auto'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'unknown'"
+        },
+        "last_checked": {
+          "name": "last_checked",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "repositories_table_short_id_unique": {
+          "name": "repositories_table_short_id_unique",
+          "columns": [
+            "short_id"
+          ],
+          "isUnique": true
+        },
+        "repositories_table_name_unique": {
+          "name": "repositories_table_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions_table": {
+      "name": "sessions_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_table_user_id_users_table_id_fk": {
+          "name": "sessions_table_user_id_users_table_id_fk",
+          "tableFrom": "sessions_table",
+          "tableTo": "users_table",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users_table": {
+      "name": "users_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "has_downloaded_restic_password": {
+          "name": "has_downloaded_restic_password",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "users_table_username_unique": {
+          "name": "users_table_username_unique",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "volumes_table": {
+      "name": "volumes_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "short_id": {
+          "name": "short_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unmounted'"
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_health_check": {
+          "name": "last_health_check",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "auto_remount": {
+          "name": "auto_remount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "volumes_table_short_id_unique": {
+          "name": "volumes_table_short_id_unique",
+          "columns": [
+            "short_id"
+          ],
+          "isUnique": true
+        },
+        "volumes_table_name_unique": {
+          "name": "volumes_table_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/app/drizzle/meta/_journal.json
+++ b/app/drizzle/meta/_journal.json
@@ -148,6 +148,13 @@
       "when": 1764847918249,
       "tag": "0020_even_dexter_bennett",
       "breakpoints": true
+    },
+    {
+      "idx": 21,
+      "version": "6",
+      "when": 1765307881092,
+      "tag": "0021_steady_viper",
+      "breakpoints": true
     }
   ]
 }

--- a/app/server/db/schema.ts
+++ b/app/server/db/schema.ts
@@ -141,6 +141,7 @@ export const backupScheduleNotificationsTable = sqliteTable(
 			.references(() => notificationDestinationsTable.id, { onDelete: "cascade" }),
 		notifyOnStart: int("notify_on_start", { mode: "boolean" }).notNull().default(false),
 		notifyOnSuccess: int("notify_on_success", { mode: "boolean" }).notNull().default(false),
+		notifyOnWarning: int("notify_on_warning", { mode: "boolean" }).notNull().default(true),
 		notifyOnFailure: int("notify_on_failure", { mode: "boolean" }).notNull().default(true),
 		createdAt: int("created_at", { mode: "number" }).notNull().default(sql`(unixepoch() * 1000)`),
 	},

--- a/app/server/modules/notifications/notifications.dto.ts
+++ b/app/server/modules/notifications/notifications.dto.ts
@@ -190,6 +190,7 @@ export const scheduleNotificationAssignmentSchema = type({
 	destinationId: "number",
 	notifyOnStart: "boolean",
 	notifyOnSuccess: "boolean",
+	notifyOnWarning: "boolean",
 	notifyOnFailure: "boolean",
 	createdAt: "number",
 	destination: notificationDestinationSchema,
@@ -227,6 +228,7 @@ export const updateScheduleNotificationsBody = type({
 		destinationId: "number",
 		notifyOnStart: "boolean",
 		notifyOnSuccess: "boolean",
+		notifyOnWarning: "boolean",
 		notifyOnFailure: "boolean",
 	}).array(),
 });

--- a/app/server/modules/notifications/notifications.service.ts
+++ b/app/server/modules/notifications/notifications.service.ts
@@ -253,6 +253,7 @@ const updateScheduleNotifications = async (
 		destinationId: number;
 		notifyOnStart: boolean;
 		notifyOnSuccess: boolean;
+		notifyOnWarning: boolean;
 		notifyOnFailure: boolean;
 	}>,
 ) => {
@@ -300,8 +301,9 @@ const sendBackupNotification = async (
 					return assignment.notifyOnStart;
 				case "success":
 					return assignment.notifyOnSuccess;
-				case "failure":
 				case "warning":
+					return assignment.notifyOnWarning;
+				case "failure":
 					return assignment.notifyOnFailure;
 				default:
 					return false;


### PR DESCRIPTION
Closes #117 

This pull request adds support for "warning" notifications to the backup schedule notification system, allowing users to configure and receive notifications specifically for backup jobs that complete with warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for warning-level notifications in backup schedules. Users can now configure notifications to be sent when backup warnings occur, alongside existing start, success, and failure events. The notification configuration UI now displays separate columns for warnings and failures for improved clarity and control over notification preferences.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->