### PR TITLE
Sanitize config payloads to prevent nested/duplicated JSON in DB

### DIFF
--- a/app/client/modules/notifications/components/create-notification-form.tsx
+++ b/app/client/modules/notifications/components/create-notification-form.tsx
@@ -17,7 +17,8 @@ import { Input } from "~/client/components/ui/input";
 import { SecretInput } from "~/client/components/ui/secret-input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "~/client/components/ui/select";
 import { Checkbox } from "~/client/components/ui/checkbox";
-import { notificationConfigSchema } from "~/schemas/notifications";
+import { NOTIFICATION_CONFIG_SHAPES, notificationConfigSchema, type NotificationConfig } from "~/schemas/notifications";
+import { stripDiscriminatedUnion } from "~/utils/object";
 
 export const formSchema = type({
 	name: "2<=string<=32",
@@ -25,6 +26,9 @@ export const formSchema = type({
 const cleanSchema = type.pipe((d) => formSchema(deepClean(d)));
 
 export type NotificationFormValues = typeof formSchema.inferIn;
+
+export const toNotificationConfig = (values: NotificationFormValues): NotificationConfig =>
+	stripDiscriminatedUnion(values, "type", NOTIFICATION_CONFIG_SHAPES) as unknown as NotificationConfig;
 
 type Props = {
 	onSubmit: (values: NotificationFormValues) => void;

--- a/app/client/modules/notifications/routes/create-notification.tsx
+++ b/app/client/modules/notifications/routes/create-notification.tsx
@@ -9,7 +9,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "~/client/components/ui
 import { parseError } from "~/client/lib/errors";
 import type { Route } from "./+types/create-notification";
 import { Alert, AlertDescription } from "~/client/components/ui/alert";
-import { CreateNotificationForm, type NotificationFormValues } from "../components/create-notification-form";
+import { CreateNotificationForm, type NotificationFormValues, toNotificationConfig } from "../components/create-notification-form";
 
 export const handle = {
 	breadcrumb: () => [{ label: "Notifications", href: "/notifications" }, { label: "Create" }],
@@ -38,7 +38,7 @@ export default function CreateNotification() {
 	});
 
 	const handleSubmit = (values: NotificationFormValues) => {
-		createNotification.mutate({ body: { name: values.name, config: values } });
+		createNotification.mutate({ body: { name: values.name, config: toNotificationConfig(values) } });
 	};
 
 	return (

--- a/app/client/modules/notifications/routes/notification-details.tsx
+++ b/app/client/modules/notifications/routes/notification-details.tsx
@@ -26,7 +26,7 @@ import { cn } from "~/client/lib/utils";
 import { Card, CardContent, CardHeader, CardTitle } from "~/client/components/ui/card";
 import { Bell, Save, TestTube2, Trash2, X } from "lucide-react";
 import { Alert, AlertDescription } from "~/client/components/ui/alert";
-import { CreateNotificationForm, type NotificationFormValues } from "../components/create-notification-form";
+import { CreateNotificationForm, type NotificationFormValues, toNotificationConfig } from "../components/create-notification-form";
 
 export const handle = {
 	breadcrumb: (match: Route.MetaArgs) => [
@@ -109,7 +109,7 @@ export default function NotificationDetailsPage({ loaderData }: Route.ComponentP
 			path: { id: String(data.id) },
 			body: {
 				name: values.name,
-				config: values,
+				config: toNotificationConfig(values),
 			},
 		});
 	};
@@ -172,7 +172,12 @@ export default function NotificationDetailsPage({ loaderData }: Route.ComponentP
 							</AlertDescription>
 						</Alert>
 					)}
-					<CreateNotificationForm mode="update" formId={formId} onSubmit={handleSubmit} initialValues={data.config} />
+					<CreateNotificationForm
+						mode="update"
+						formId={formId}
+						onSubmit={handleSubmit}
+						initialValues={{ name: data.name, ...data.config }}
+					/>
 					<div className="flex justify-end gap-2 pt-4 border-t">
 						<Button type="submit" form={formId} loading={updateDestination.isPending}>
 							<Save className="h-4 w-4 mr-2" />

--- a/app/client/modules/repositories/components/create-repository-form.tsx
+++ b/app/client/modules/repositories/components/create-repository-form.tsx
@@ -20,8 +20,9 @@ import { SecretInput } from "../../../components/ui/secret-input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "../../../components/ui/select";
 import { Tooltip, TooltipContent, TooltipTrigger } from "../../../components/ui/tooltip";
 import { useSystemInfo } from "~/client/hooks/use-system-info";
-import { COMPRESSION_MODES, repositoryConfigSchema } from "~/schemas/restic";
+import { COMPRESSION_MODES, REPOSITORY_CONFIG_SHAPES, repositoryConfigSchema, type RepositoryConfig } from "~/schemas/restic";
 import { Checkbox } from "../../../components/ui/checkbox";
+import { stripDiscriminatedUnion } from "~/utils/object";
 import {
 	LocalRepositoryForm,
 	S3RepositoryForm,
@@ -40,6 +41,9 @@ export const formSchema = type({
 const cleanSchema = type.pipe((d) => formSchema(deepClean(d)));
 
 export type RepositoryFormValues = typeof formSchema.inferIn;
+
+export const toRepositoryConfig = (values: RepositoryFormValues): RepositoryConfig =>
+	stripDiscriminatedUnion(values, "backend", REPOSITORY_CONFIG_SHAPES) as unknown as RepositoryConfig;
 
 type Props = {
 	onSubmit: (values: RepositoryFormValues) => void;

--- a/app/client/modules/repositories/routes/create-repository.tsx
+++ b/app/client/modules/repositories/routes/create-repository.tsx
@@ -7,6 +7,7 @@ import { createRepositoryMutation } from "~/client/api-client/@tanstack/react-qu
 import {
 	CreateRepositoryForm,
 	type RepositoryFormValues,
+	toRepositoryConfig,
 } from "~/client/modules/repositories/components/create-repository-form";
 import { Button } from "~/client/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "~/client/components/ui/card";
@@ -43,7 +44,7 @@ export default function CreateRepository() {
 	const handleSubmit = (values: RepositoryFormValues) => {
 		createRepository.mutate({
 			body: {
-				config: values,
+				config: toRepositoryConfig(values),
 				name: values.name,
 				compressionMode: values.compressionMode,
 			},

--- a/app/client/modules/volumes/components/create-volume-form.tsx
+++ b/app/client/modules/volumes/components/create-volume-form.tsx
@@ -23,6 +23,8 @@ import { testConnectionMutation } from "../../../api-client/@tanstack/react-quer
 import { Tooltip, TooltipContent, TooltipTrigger } from "../../../components/ui/tooltip";
 import { useSystemInfo } from "~/client/hooks/use-system-info";
 import { DirectoryForm, NFSForm, SMBForm, WebDAVForm, RcloneForm } from "./volume-forms";
+import { VOLUME_CONFIG_SHAPES, type BackendConfig } from "~/schemas/volumes";
+import { stripDiscriminatedUnion } from "~/utils/object";
 
 export const formSchema = type({
 	name: "2<=string<=32",
@@ -30,6 +32,9 @@ export const formSchema = type({
 const cleanSchema = type.pipe((d) => formSchema(deepClean(d)));
 
 export type FormValues = typeof formSchema.inferIn;
+
+export const toBackendConfig = (values: FormValues): BackendConfig =>
+	stripDiscriminatedUnion(values, "backend", VOLUME_CONFIG_SHAPES) as unknown as BackendConfig;
 
 type Props = {
 	onSubmit: (values: FormValues) => void;
@@ -98,7 +103,7 @@ export const CreateVolumeForm = ({ onSubmit, mode = "create", initialValues, for
 
 		if (formValues.backend === "nfs" || formValues.backend === "smb" || formValues.backend === "webdav") {
 			testBackendConnection.mutate({
-				body: { config: formValues },
+				body: { config: toBackendConfig(formValues) },
 			});
 		}
 	};

--- a/app/client/modules/volumes/routes/create-volume.tsx
+++ b/app/client/modules/volumes/routes/create-volume.tsx
@@ -4,7 +4,7 @@ import { useId } from "react";
 import { useNavigate } from "react-router";
 import { toast } from "sonner";
 import { createVolumeMutation } from "~/client/api-client/@tanstack/react-query.gen";
-import { CreateVolumeForm, type FormValues } from "~/client/modules/volumes/components/create-volume-form";
+import { CreateVolumeForm, type FormValues, toBackendConfig } from "~/client/modules/volumes/components/create-volume-form";
 import { Button } from "~/client/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "~/client/components/ui/card";
 import { parseError } from "~/client/lib/errors";
@@ -40,7 +40,7 @@ export default function CreateVolume() {
 	const handleSubmit = (values: FormValues) => {
 		createVolume.mutate({
 			body: {
-				config: values,
+				config: toBackendConfig(values),
 				name: values.name,
 			},
 		});

--- a/app/client/modules/volumes/tabs/info.tsx
+++ b/app/client/modules/volumes/tabs/info.tsx
@@ -3,7 +3,7 @@ import { useState } from "react";
 import { useNavigate } from "react-router";
 import { toast } from "sonner";
 import { Check } from "lucide-react";
-import { CreateVolumeForm, type FormValues } from "~/client/modules/volumes/components/create-volume-form";
+import { CreateVolumeForm, type FormValues, toBackendConfig } from "~/client/modules/volumes/components/create-volume-form";
 import {
 	AlertDialog,
 	AlertDialogAction,
@@ -59,7 +59,7 @@ export const VolumeInfoTabContent = ({ volume, statfs }: Props) => {
 		if (pendingValues) {
 			updateMutation.mutate({
 				path: { name: volume.name },
-				body: { name: pendingValues.name, config: pendingValues },
+				body: { name: pendingValues.name, config: toBackendConfig(pendingValues) },
 			});
 		}
 	};
@@ -69,7 +69,7 @@ export const VolumeInfoTabContent = ({ volume, statfs }: Props) => {
 			<div className="grid gap-4 xl:grid-cols-[minmax(0,2.3fr)_minmax(320px,1fr)]">
 				<Card className="p-6">
 					<CreateVolumeForm
-						initialValues={{ ...volume, ...volume.config }}
+						initialValues={{ name: volume.name, ...volume.config }}
 						onSubmit={handleSubmit}
 						mode="update"
 						loading={updateMutation.isPending}

--- a/app/schemas/notifications.ts
+++ b/app/schemas/notifications.ts
@@ -13,7 +13,7 @@ export const NOTIFICATION_TYPES = {
 
 export type NotificationType = keyof typeof NOTIFICATION_TYPES;
 
-export const emailNotificationConfigSchema = type({
+export const emailNotificationConfigShape = {
 	type: "'email'",
 	smtpHost: "string",
 	smtpPort: "1 <= number <= 65535",
@@ -22,59 +22,75 @@ export const emailNotificationConfigSchema = type({
 	from: "string",
 	to: "string[]",
 	useTLS: "boolean",
-});
+} as const;
 
-export const slackNotificationConfigSchema = type({
+export const emailNotificationConfigSchema = type(emailNotificationConfigShape);
+
+export const slackNotificationConfigShape = {
 	type: "'slack'",
 	webhookUrl: "string",
 	channel: "string?",
 	username: "string?",
 	iconEmoji: "string?",
-});
+} as const;
 
-export const discordNotificationConfigSchema = type({
+export const slackNotificationConfigSchema = type(slackNotificationConfigShape);
+
+export const discordNotificationConfigShape = {
 	type: "'discord'",
 	webhookUrl: "string",
 	username: "string?",
 	avatarUrl: "string?",
 	threadId: "string?",
-});
+} as const;
 
-export const gotifyNotificationConfigSchema = type({
+export const discordNotificationConfigSchema = type(discordNotificationConfigShape);
+
+export const gotifyNotificationConfigShape = {
 	type: "'gotify'",
 	serverUrl: "string",
 	token: "string",
 	path: "string?",
 	priority: "0 <= number <= 10",
-});
+} as const;
 
-export const ntfyNotificationConfigSchema = type({
+export const gotifyNotificationConfigSchema = type(gotifyNotificationConfigShape);
+
+export const ntfyNotificationConfigShape = {
 	type: "'ntfy'",
 	serverUrl: "string?",
 	topic: "string",
 	priority: "'max' | 'high' | 'default' | 'low' | 'min'",
 	username: "string?",
 	password: "string?",
-});
+} as const;
 
-export const pushoverNotificationConfigSchema = type({
+export const ntfyNotificationConfigSchema = type(ntfyNotificationConfigShape);
+
+export const pushoverNotificationConfigShape = {
 	type: "'pushover'",
 	userKey: "string",
 	apiToken: "string",
 	devices: "string?",
 	priority: "-1 | 0 | 1",
-});
+} as const;
 
-export const telegramNotificationConfigSchema = type({
+export const pushoverNotificationConfigSchema = type(pushoverNotificationConfigShape);
+
+export const telegramNotificationConfigShape = {
 	type: "'telegram'",
 	botToken: "string",
 	chatId: "string",
-});
+} as const;
 
-export const customNotificationConfigSchema = type({
+export const telegramNotificationConfigSchema = type(telegramNotificationConfigShape);
+
+export const customNotificationConfigShape = {
 	type: "'custom'",
 	shoutrrrUrl: "string",
-});
+} as const;
+
+export const customNotificationConfigSchema = type(customNotificationConfigShape);
 
 export const notificationConfigSchema = emailNotificationConfigSchema
 	.or(slackNotificationConfigSchema)
@@ -86,6 +102,17 @@ export const notificationConfigSchema = emailNotificationConfigSchema
 	.or(customNotificationConfigSchema);
 
 export type NotificationConfig = typeof notificationConfigSchema.infer;
+
+export const NOTIFICATION_CONFIG_SHAPES = {
+	email: emailNotificationConfigShape,
+	slack: slackNotificationConfigShape,
+	discord: discordNotificationConfigShape,
+	gotify: gotifyNotificationConfigShape,
+	ntfy: ntfyNotificationConfigShape,
+	pushover: pushoverNotificationConfigShape,
+	telegram: telegramNotificationConfigShape,
+	custom: customNotificationConfigShape,
+} as const;
 
 export const NOTIFICATION_EVENTS = {
 	start: "start",

--- a/app/schemas/restic.ts
+++ b/app/schemas/restic.ts
@@ -14,70 +14,88 @@ export const REPOSITORY_BACKENDS = {
 export type RepositoryBackend = keyof typeof REPOSITORY_BACKENDS;
 
 // Common fields for all repository configs
-const baseRepositoryConfigSchema = type({
+export const baseRepositoryConfigShape = {
 	isExistingRepository: "boolean?",
 	customPassword: "string?",
-});
+} as const;
 
-export const s3RepositoryConfigSchema = type({
+const baseRepositoryConfigSchema = type(baseRepositoryConfigShape);
+
+export const s3RepositoryConfigShape = {
 	backend: "'s3'",
 	endpoint: "string",
 	bucket: "string",
 	accessKeyId: "string",
 	secretAccessKey: "string",
-}).and(baseRepositoryConfigSchema);
+} as const;
 
-export const r2RepositoryConfigSchema = type({
+export const s3RepositoryConfigSchema = type(s3RepositoryConfigShape).and(baseRepositoryConfigSchema);
+
+export const r2RepositoryConfigShape = {
 	backend: "'r2'",
 	endpoint: "string",
 	bucket: "string",
 	accessKeyId: "string",
 	secretAccessKey: "string",
-}).and(baseRepositoryConfigSchema);
+} as const;
 
-export const localRepositoryConfigSchema = type({
+export const r2RepositoryConfigSchema = type(r2RepositoryConfigShape).and(baseRepositoryConfigSchema);
+
+export const localRepositoryConfigShape = {
 	backend: "'local'",
 	name: "string",
 	path: "string?",
-}).and(baseRepositoryConfigSchema);
+} as const;
 
-export const gcsRepositoryConfigSchema = type({
+export const localRepositoryConfigSchema = type(localRepositoryConfigShape).and(baseRepositoryConfigSchema);
+
+export const gcsRepositoryConfigShape = {
 	backend: "'gcs'",
 	bucket: "string",
 	projectId: "string",
 	credentialsJson: "string",
-}).and(baseRepositoryConfigSchema);
+} as const;
 
-export const azureRepositoryConfigSchema = type({
+export const gcsRepositoryConfigSchema = type(gcsRepositoryConfigShape).and(baseRepositoryConfigSchema);
+
+export const azureRepositoryConfigShape = {
 	backend: "'azure'",
 	container: "string",
 	accountName: "string",
 	accountKey: "string",
 	endpointSuffix: "string?",
-}).and(baseRepositoryConfigSchema);
+} as const;
 
-export const rcloneRepositoryConfigSchema = type({
+export const azureRepositoryConfigSchema = type(azureRepositoryConfigShape).and(baseRepositoryConfigSchema);
+
+export const rcloneRepositoryConfigShape = {
 	backend: "'rclone'",
 	remote: "string",
 	path: "string",
-}).and(baseRepositoryConfigSchema);
+} as const;
 
-export const restRepositoryConfigSchema = type({
+export const rcloneRepositoryConfigSchema = type(rcloneRepositoryConfigShape).and(baseRepositoryConfigSchema);
+
+export const restRepositoryConfigShape = {
 	backend: "'rest'",
 	url: "string",
 	username: "string?",
 	password: "string?",
 	path: "string?",
-}).and(baseRepositoryConfigSchema);
+} as const;
 
-export const sftpRepositoryConfigSchema = type({
+export const restRepositoryConfigSchema = type(restRepositoryConfigShape).and(baseRepositoryConfigSchema);
+
+export const sftpRepositoryConfigShape = {
 	backend: "'sftp'",
 	host: "string",
 	port: type("string.integer").or(type("number")).to("1 <= number <= 65535").default(22),
 	user: "string",
 	path: "string",
 	privateKey: "string",
-}).and(baseRepositoryConfigSchema);
+} as const;
+
+export const sftpRepositoryConfigSchema = type(sftpRepositoryConfigShape).and(baseRepositoryConfigSchema);
 
 export const repositoryConfigSchema = s3RepositoryConfigSchema
 	.or(r2RepositoryConfigSchema)
@@ -89,6 +107,17 @@ export const repositoryConfigSchema = s3RepositoryConfigSchema
 	.or(sftpRepositoryConfigSchema);
 
 export type RepositoryConfig = typeof repositoryConfigSchema.infer;
+
+export const REPOSITORY_CONFIG_SHAPES = {
+	local: { ...baseRepositoryConfigShape, ...localRepositoryConfigShape },
+	s3: { ...baseRepositoryConfigShape, ...s3RepositoryConfigShape },
+	r2: { ...baseRepositoryConfigShape, ...r2RepositoryConfigShape },
+	gcs: { ...baseRepositoryConfigShape, ...gcsRepositoryConfigShape },
+	azure: { ...baseRepositoryConfigShape, ...azureRepositoryConfigShape },
+	rclone: { ...baseRepositoryConfigShape, ...rcloneRepositoryConfigShape },
+	rest: { ...baseRepositoryConfigShape, ...restRepositoryConfigShape },
+	sftp: { ...baseRepositoryConfigShape, ...sftpRepositoryConfigShape },
+} as const;
 
 export const COMPRESSION_MODES = {
 	off: "off",

--- a/app/schemas/volumes.ts
+++ b/app/schemas/volumes.ts
@@ -10,16 +10,18 @@ export const BACKEND_TYPES = {
 
 export type BackendType = keyof typeof BACKEND_TYPES;
 
-export const nfsConfigSchema = type({
+export const nfsConfigShape = {
 	backend: "'nfs'",
 	server: "string",
 	exportPath: "string",
 	port: type("string.integer").or(type("number")).to("1 <= number <= 65536").default(2049),
 	version: "'3' | '4' | '4.1'",
 	readOnly: "boolean?",
-});
+} as const;
 
-export const smbConfigSchema = type({
+export const nfsConfigSchema = type(nfsConfigShape);
+
+export const smbConfigShape = {
 	backend: "'smb'",
 	server: "string",
 	share: "string",
@@ -29,15 +31,19 @@ export const smbConfigSchema = type({
 	domain: "string?",
 	port: type("string.integer").or(type("number")).to("1 <= number <= 65535").default(445),
 	readOnly: "boolean?",
-});
+} as const;
 
-export const directoryConfigSchema = type({
+export const smbConfigSchema = type(smbConfigShape);
+
+export const directoryConfigShape = {
 	backend: "'directory'",
 	path: "string",
 	readOnly: "false?",
-});
+} as const;
 
-export const webdavConfigSchema = type({
+export const directoryConfigSchema = type(directoryConfigShape);
+
+export const webdavConfigShape = {
 	backend: "'webdav'",
 	server: "string",
 	path: "string",
@@ -46,18 +52,30 @@ export const webdavConfigSchema = type({
 	port: type("string.integer").or(type("number")).to("1 <= number <= 65536").default(80),
 	readOnly: "boolean?",
 	ssl: "boolean?",
-});
+} as const;
 
-export const rcloneConfigSchema = type({
+export const webdavConfigSchema = type(webdavConfigShape);
+
+export const rcloneConfigShape = {
 	backend: "'rclone'",
 	remote: "string",
 	path: "string",
 	readOnly: "boolean?",
-});
+} as const;
+
+export const rcloneConfigSchema = type(rcloneConfigShape);
 
 export const volumeConfigSchema = nfsConfigSchema.or(smbConfigSchema).or(webdavConfigSchema).or(directoryConfigSchema).or(rcloneConfigSchema);
 
 export type BackendConfig = typeof volumeConfigSchema.infer;
+
+export const VOLUME_CONFIG_SHAPES = {
+	nfs: nfsConfigShape,
+	smb: smbConfigShape,
+	webdav: webdavConfigShape,
+	directory: directoryConfigShape,
+	rclone: rcloneConfigShape,
+} as const;
 
 export const BACKEND_STATUS = {
 	mounted: "mounted",

--- a/app/utils/object.ts
+++ b/app/utils/object.ts
@@ -1,3 +1,11 @@
+/**
+ * Deeply removes empty-ish values from an object/array tree.
+ *
+ * - Arrays: maps + filters out `undefined`, `null`, and empty strings.
+ * - Objects: recursively cleans values and drops keys whose cleaned value is `undefined` or "".
+ *
+ * Note: this function is intended for building payloads; it does not preserve object prototypes.
+ */
 export function deepClean<T>(obj: T): T {
 	if (Array.isArray(obj)) {
 		return obj.map(deepClean).filter((v) => v !== undefined && v !== null && v !== "") as T;
@@ -11,4 +19,61 @@ export function deepClean<T>(obj: T): T {
 		}, {} as T);
 	}
 	return obj;
+}
+
+/**
+ * A "shape" describes the allowed top-level keys for an object.
+ *
+ * The values are irrelevant; only the keys matter.
+ */
+type Shape = Record<string, unknown>;
+
+/**
+ * Strips an object to only the keys present in the provided shape.
+ *
+ * - This is a shallow operation (top-level keys only).
+ * - Missing keys become `undefined` in the returned object.
+ *
+ * This is used to avoid persisting polluted objects (e.g. form state) into DB `config` JSON blobs.
+ */
+export function stripToShape<T extends Record<string, unknown>, S extends Shape>(obj: T, shape: S): {
+	[K in keyof S]: K extends keyof T ? T[K] : undefined;
+} {
+	const result: Record<string, unknown> = {};
+	for (const key of Object.keys(shape)) {
+		result[key] = (obj as Record<string, unknown>)[key];
+	}
+	return result as {
+		[K in keyof S]: K extends keyof T ? T[K] : undefined;
+	};
+}
+
+/**
+ * Strips a discriminated-union object to only the keys allowed for its variant.
+ *
+ * Example: given `discriminantKey = "backend"` and a map of backend -> shape,
+ * this returns `stripToShape(obj, shapes[obj.backend])`.
+ *
+ * Fallback behavior:
+ * - If the discriminant value is not a string, or there is no matching shape,
+ *   the original object is returned unchanged.
+ */
+export function stripDiscriminatedUnion<
+	T extends Record<string, unknown>,
+	DiscriminantKey extends keyof T,
+	Shapes extends Record<string, Shape>,
+>(
+	obj: T,
+	discriminantKey: DiscriminantKey,
+	shapes: Shapes,
+): Record<string, unknown> {
+	const discriminant = obj[discriminantKey];
+	if (typeof discriminant !== "string") {
+		return obj;
+	}
+	const shape = shapes[discriminant];
+	if (!shape) {
+		return obj;
+	}
+	return stripToShape(obj, shape);
 }


### PR DESCRIPTION
### Summary
Fixes a bug where `config` JSON could accidentally include extra fields (or even another nested `config`) after create/update operations. We now enforce that `config` stored in SQLite contains only the backend/type-specific config fields.

### What changed
- Introduced schema-driven stripping for discriminated union configs:
  - Volumes: `backend` → allowed config keys
  - Repositories: `backend` → allowed config keys
  - Notifications: `type` → allowed config keys
- Client: create/update/test now send only the stripped config (not the full form state).
- Server: strips again before encrypting/persisting (to be sure).
- Sanitize first, then encrypt (`config` → `sanitizedConfig` → `encryptedConfig`).
- Fixed form initialization that previously merged top-level entity fields into config-shaped state.

### Why
Validation alone wasn’t enough: ArkType checks required keys but does not remove unknown keys, so polluted configs could pass validation and be stored.

### How to test
- Create/update volumes, repositories, and notification destinations.
- Confirm the DB `config` JSON is clean (no nested `config`, no top-level entity fields).


### Related issues
Data model: Duplicate fields stored in both dedicated field and config field #151

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored configuration transformation logic across notifications, repositories, and volume modules to improve data consistency
  * Enhanced configuration validation by sanitizing input data to ensure only valid fields are stored
  * Streamlined form submission processes with improved configuration handling and data transformation
  * Reorganized and consolidated configuration schemas for better code maintainability

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->