### PR TITLE
Better SMB Mount Compatability

### DIFF
--- a/app/server/modules/backends/smb/smb-backend.ts
+++ b/app/server/modules/backends/smb/smb-backend.ts
@@ -38,8 +38,8 @@ const mount = async (config: BackendConfig, path: string) => {
 
 		const source = `//${config.server}/${config.share}`;
 		const options = [
-			`user=${config.username}`,
-			`pass=${password}`,
+			`username=${config.username}`,
+			`password=${password}`,
 			`vers=${config.vers}`,
 			`port=${config.port}`,
 			"uid=1000",


### PR DESCRIPTION
change mount command to username/password instead of user/pass so that it works with mount.cifs ubuntu server 24.04

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SMB mounting compatibility by updating configuration parameters to use standard naming conventions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->