### PR TITLE
refactor: reduce startup mounting noise

### DIFF
--- a/app/server/modules/backends/nfs/nfs-backend.ts
+++ b/app/server/modules/backends/nfs/nfs-backend.ts
@@ -27,8 +27,10 @@ const mount = async (config: BackendConfig, path: string) => {
 		return { status: BACKEND_STATUS.mounted };
 	}
 
-	logger.debug(`Trying to unmount any existing mounts at ${path} before mounting...`);
-	await unmount(path);
+	if (status === "error") {
+		logger.debug(`Trying to unmount any existing mounts at ${path} before mounting...`);
+		await unmount(path);
+	}
 
 	const run = async () => {
 		await fs.mkdir(path, { recursive: true });
@@ -64,16 +66,15 @@ const unmount = async (path: string) => {
 	}
 
 	const run = async () => {
-		try {
-			await fs.access(path);
-		} catch {
-			logger.warn(`Path ${path} does not exist. Skipping unmount.`);
+		const mount = await getMountForPath(path);
+		if (!mount || mount.mountPoint !== path) {
+			logger.debug(`Path ${path} is not a mount point. Skipping unmount.`);
 			return { status: BACKEND_STATUS.unmounted };
 		}
 
 		await executeUnmount(path);
 
-		await fs.rmdir(path);
+		await fs.rmdir(path).catch(() => {});
 
 		logger.info(`NFS volume at ${path} unmounted successfully.`);
 		return { status: BACKEND_STATUS.unmounted };
@@ -89,13 +90,20 @@ const unmount = async (path: string) => {
 
 const checkHealth = async (path: string) => {
 	const run = async () => {
-		logger.debug(`Checking health of NFS volume at ${path}...`);
-		await fs.access(path);
+		try {
+			await fs.access(path);
+		} catch {
+			throw new Error("Volume is not mounted");
+		}
 
 		const mount = await getMountForPath(path);
 
-		if (!mount || !mount.fstype.startsWith("nfs")) {
-			throw new Error(`Path ${path} is not mounted as NFS.`);
+		if (!mount || mount.mountPoint !== path) {
+			throw new Error("Volume is not mounted");
+		}
+
+		if (!mount.fstype.startsWith("nfs")) {
+			throw new Error(`Path ${path} is not mounted as NFS (found ${mount.fstype}).`);
 		}
 
 		logger.debug(`NFS volume at ${path} is healthy and mounted.`);
@@ -105,8 +113,11 @@ const checkHealth = async (path: string) => {
 	try {
 		return await withTimeout(run(), OPERATION_TIMEOUT, "NFS health check");
 	} catch (error) {
-		logger.error("NFS volume health check failed:", toMessage(error));
-		return { status: BACKEND_STATUS.error, error: toMessage(error) };
+		const message = toMessage(error);
+		if (message !== "Volume is not mounted") {
+			logger.error("NFS volume health check failed:", message);
+		}
+		return { status: BACKEND_STATUS.error, error: message };
 	}
 };
 

--- a/app/server/modules/backends/smb/smb-backend.ts
+++ b/app/server/modules/backends/smb/smb-backend.ts
@@ -28,8 +28,10 @@ const mount = async (config: BackendConfig, path: string) => {
 		return { status: BACKEND_STATUS.mounted };
 	}
 
-	logger.debug(`Trying to unmount any existing mounts at ${path} before mounting...`);
-	await unmount(path);
+	if (status === "error") {
+		logger.debug(`Trying to unmount any existing mounts at ${path} before mounting...`);
+		await unmount(path);
+	}
 
 	const run = async () => {
 		await fs.mkdir(path, { recursive: true });
@@ -80,16 +82,15 @@ const unmount = async (path: string) => {
 	}
 
 	const run = async () => {
-		try {
-			await fs.access(path);
-		} catch {
-			logger.warn(`Path ${path} does not exist. Skipping unmount.`);
+		const mount = await getMountForPath(path);
+		if (!mount || mount.mountPoint !== path) {
+			logger.debug(`Path ${path} is not a mount point. Skipping unmount.`);
 			return { status: BACKEND_STATUS.unmounted };
 		}
 
 		await executeUnmount(path);
 
-		await fs.rmdir(path);
+		await fs.rmdir(path).catch(() => {});
 
 		logger.info(`SMB volume at ${path} unmounted successfully.`);
 		return { status: BACKEND_STATUS.unmounted };
@@ -105,13 +106,20 @@ const unmount = async (path: string) => {
 
 const checkHealth = async (path: string) => {
 	const run = async () => {
-		logger.debug(`Checking health of SMB volume at ${path}...`);
-		await fs.access(path);
+		try {
+			await fs.access(path);
+		} catch {
+			throw new Error("Volume is not mounted");
+		}
 
 		const mount = await getMountForPath(path);
 
-		if (!mount || mount.fstype !== "cifs") {
-			throw new Error(`Path ${path} is not mounted as CIFS/SMB.`);
+		if (!mount || mount.mountPoint !== path) {
+			throw new Error("Volume is not mounted");
+		}
+
+		if (mount.fstype !== "cifs") {
+			throw new Error(`Path ${path} is not mounted as CIFS/SMB (found ${mount.fstype}).`);
 		}
 
 		logger.debug(`SMB volume at ${path} is healthy and mounted.`);
@@ -121,8 +129,11 @@ const checkHealth = async (path: string) => {
 	try {
 		return await withTimeout(run(), OPERATION_TIMEOUT, "SMB health check");
 	} catch (error) {
-		logger.error("SMB volume health check failed:", toMessage(error));
-		return { status: BACKEND_STATUS.error, error: toMessage(error) };
+		const message = toMessage(error);
+		if (message !== "Volume is not mounted") {
+			logger.error("SMB volume health check failed:", message);
+		}
+		return { status: BACKEND_STATUS.error, error: message };
 	}
 };
 


### PR DESCRIPTION
- Skip unmount early if volume is not in error or neither mounted
- Error healthchecks early if volume is not even mounted
- Fix duplicate mont execution in webdav backend

This reduces the error noise in the early startup of the container

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized mount/unmount flow for storage backends: unmounting now occurs conditionally only when health checks indicate errors, improving efficiency
  * Enhanced mount-point validation and error handling across NFS, rclone, SMB, and WebDAV storage backends
  * Refined error logging to reduce noise while preserving diagnostic information for troubleshooting

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->