### PR TITLE
refactor: add default excludes to backups

### DIFF
--- a/app/server/core/constants.ts
+++ b/app/server/core/constants.ts
@@ -4,4 +4,10 @@ export const REPOSITORY_BASE = "/var/lib/zerobyte/repositories";
 export const DATABASE_URL = "/var/lib/zerobyte/data/ironmount.db";
 export const RESTIC_PASS_FILE = "/var/lib/zerobyte/data/restic.pass";
 
+export const DEFAULT_EXCLUDES = [
+	DATABASE_URL,
+	RESTIC_PASS_FILE,
+	"/var/lib/zerobyte/repositories/**", // To avoid circular backups
+];
+
 export const REQUIRED_MIGRATIONS = ["v0.14.0"];

--- a/app/server/utils/restic.ts
+++ b/app/server/utils/restic.ts
@@ -5,7 +5,7 @@ import os from "node:os";
 import { throttle } from "es-toolkit";
 import { type } from "arktype";
 import { $ } from "bun";
-import { REPOSITORY_BASE, RESTIC_PASS_FILE } from "../core/constants";
+import { REPOSITORY_BASE, RESTIC_PASS_FILE, DEFAULT_EXCLUDES } from "../core/constants";
 import { logger } from "./logger";
 import { cryptoUtils } from "./crypto";
 import type { RetentionPolicy } from "../modules/backups/backups.dto";
@@ -273,6 +273,10 @@ const backup = async (
 		args.push("--files-from", includeFile);
 	} else {
 		args.push(source);
+	}
+
+	for (const exclude of DEFAULT_EXCLUDES) {
+		args.push("--exclude", exclude);
 	}
 
 	if (options?.exclude && options.exclude.length > 0) {


### PR DESCRIPTION
- To avoid accidentaly backing up a repository to itself
- To avoid accidentaly backing up zerobyte's internal data

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Backup operations now automatically exclude sensitive files and directories (database configuration, authentication credentials, and backup repositories) to prevent unintended backups and circular dependency issues.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->