### PR TITLE
fix: include name in initial values for notification form update

### DIFF
--- a/app/client/modules/notifications/routes/notification-details.tsx
+++ b/app/client/modules/notifications/routes/notification-details.tsx
@@ -172,7 +172,15 @@ export default function NotificationDetailsPage({ loaderData }: Route.ComponentP
 							</AlertDescription>
 						</Alert>
 					)}
-					<CreateNotificationForm mode="update" formId={formId} onSubmit={handleSubmit} initialValues={data.config} />
+					<CreateNotificationForm
+						mode="update"
+						formId={formId}
+						onSubmit={handleSubmit}
+						initialValues={{
+							...data.config,
+							name: data.name,
+						}}
+					/>
 					<div className="flex justify-end gap-2 pt-4 border-t">
 						<Button type="submit" form={formId} loading={updateDestination.isPending}>
 							<Save className="h-4 w-4 mr-2" />


### PR DESCRIPTION
This pull request updates the way initial values are passed to the `CreateNotificationForm` component on the notification details page. The change ensures that the `name` field from the notification data is explicitly included in the form's initial values, which may help with form population or editing scenarios.

- Passes the `name` property from `data` into the `initialValues` object for `CreateNotificationForm`, in addition to the existing `data.config` properties.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed notification update form to properly initialize with all required fields when editing a notification, ensuring the notification name and configuration details are correctly pre-filled.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->