### PR TITLE
fix: import local repository with selected path

### DIFF
--- a/app/server/modules/repositories/repositories.service.ts
+++ b/app/server/modules/repositories/repositories.service.ts
@@ -76,10 +76,15 @@ const createRepository = async (name: string, config: RepositoryConfig, compress
 	if (config.backend === "local") {
 		if (config.isExistingRepository && config.path) {
 			const normalizedPath = path.normalize(config.path);
+			const repositoryName = path.basename(normalizedPath);
+
+			if (!repositoryName || repositoryName.trim().length === 0) {
+				throw new ConflictError("Local repository path must include a folder name.");
+			}
 			processedConfig = {
 				...config,
 				path: path.dirname(normalizedPath),
-				name: path.basename(normalizedPath),
+				name: repositoryName,
 			};
 		} else {
 			processedConfig = { ...config, name: shortId };


### PR DESCRIPTION
While importing remote repositories work great, importing existing local repositories doesn't work correctly. 

Importing local repo gives you following error: 

```
Failed to create repository:
Failed to initialize repository: Restic snapshots retrieval failed: {"message_type":"exit_error","code":10,"message":"Fatal: repository does not exist: unable to open config file: stat {selected_path_to_repo}/HsjEf/config: no such file or directory\nIs there a repository at the following location?\n/{selected_path_to_repo}/HsjEf"}
```

It happens because backend generates `shortId` when you create new repository even you actually import existing one and provide complete path to repo folder. 

Changed behavior to use provided path for repo when importing existing local repository.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Local repository creation now derives the repository name and stored path from a provided filesystem path when adding an existing repository.
* **Bug Fixes**
  * Added path normalization and validation to prevent empty or invalid repository names and ensure consistent stored paths.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->