### PR TITLE
fix: add missing path property to webdav and rclone default values

### DIFF
--- a/app/client/modules/volumes/components/create-volume-form.tsx
+++ b/app/client/modules/volumes/components/create-volume-form.tsx
@@ -44,7 +44,7 @@ const defaultValuesForType = {
 	directory: { backend: "directory" as const, path: "/" },
 	nfs: { backend: "nfs" as const, port: 2049, version: "4.1" as const },
 	smb: { backend: "smb" as const, port: 445, vers: "3.0" as const },
-	webdav: { backend: "webdav" as const, port: 80, ssl: false, path: "/" },
+	webdav: { backend: "webdav" as const, port: 80, ssl: false, path: "/webdav" },
 	rclone: { backend: "rclone" as const, path: "/" },
 };
 


### PR DESCRIPTION
## Fix missing default `path` for WebDAV and rclone volume backends

### Problem

When creating a new volume and switching to the **WebDAV** or **rclone** backend type, the form would fail validation with the error:

```
path must be a string (was missing)
```

The "Test Connection" button would also fail with a 400 error without showing a clear error message to the user.

And that's even though there is a `/` in the field filled in from the local backend form.

### Root Cause

The `defaultValuesForType` object in create-volume-form.tsx was missing the required `path` field for WebDAV and rclone backends:

```typescript
const defaultValuesForType = {
  directory: { backend: "directory" as const, path: "/" },
  nfs: { backend: "nfs" as const, port: 2049, version: "4.1" as const },
  smb: { backend: "smb" as const, port: 445, vers: "3.0" as const },
  webdav: { backend: "webdav" as const, port: 80, ssl: false },  // ❌ missing path
  rclone: { backend: "rclone" as const },                         // ❌ missing path
};
```

When switching backends, the form resets using these defaults. Since `path` is a required field in the schema for both WebDAV and rclone, validation failed both client-side (on submit) and server-side (on test connection).

### Solution

Added `path` to both WebDAV and rclone default values:

```typescript
const defaultValuesForType = {
  directory: { backend: "directory" as const, path: "/" },
  nfs: { backend: "nfs" as const, port: 2049, version: "4.1" as const },
  smb: { backend: "smb" as const, port: 445, vers: "3.0" as const },
  webdav: { backend: "webdav" as const, port: 80, ssl: false, path: "/webdav" },  // ✅ 
  rclone: { backend: "rclone" as const, path: "/" },                         // ✅
};
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed default path values for webdav and rclone backends in the volume creation form. WebDAV now defaults to "/webdav" and rclone defaults to "/" when creating new volumes, ensuring form fields are properly pre-populated.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->