### PR TITLE
feat: allow changing the hostname (restic host)

### DIFF
--- a/app/server/core/config.ts
+++ b/app/server/core/config.ts
@@ -5,11 +5,13 @@ const envSchema = type({
 	NODE_ENV: type.enumerated("development", "production", "test").default("production"),
 	SERVER_IP: 'string = "localhost"',
 	SERVER_IDLE_TIMEOUT: 'string.integer.parse = "60"',
+	RESTIC_HOSTNAME: "string = 'zerobyte'",
 }).pipe((s) => ({
 	__prod__: s.NODE_ENV === "production",
 	environment: s.NODE_ENV,
 	serverIp: s.SERVER_IP,
 	serverIdleTimeout: s.SERVER_IDLE_TIMEOUT,
+	resticHostname: s.RESTIC_HOSTNAME,
 }));
 
 const parseConfig = (env: unknown) => {

--- a/app/server/utils/restic.ts
+++ b/app/server/utils/restic.ts
@@ -5,6 +5,7 @@ import os from "node:os";
 import { throttle } from "es-toolkit";
 import { type } from "arktype";
 import { REPOSITORY_BASE, RESTIC_PASS_FILE, DEFAULT_EXCLUDES } from "../core/constants";
+import { config as appConfig } from "../core/config";
 import { logger } from "./logger";
 import { cryptoUtils } from "./crypto";
 import type { RetentionPolicy } from "../modules/backups/backups.dto";
@@ -260,6 +261,10 @@ const backup = async (
 
 	if (options?.oneFileSystem) {
 		args.push("--one-file-system");
+	}
+
+	if (appConfig.resticHostname) {
+		args.push("--host", appConfig.resticHostname);
 	}
 
 	if (options?.tags && options.tags.length > 0) {


### PR DESCRIPTION
Closes #129

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring a custom hostname for backup operations. Users can now specify their preferred hostname via environment configuration to customize backup settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->