### PR TITLE
fix: update NFS version select to use controlled value

### DIFF
--- a/app/client/modules/volumes/components/volume-forms/nfs-form.tsx
+++ b/app/client/modules/volumes/components/volume-forms/nfs-form.tsx
@@ -73,7 +73,7 @@ export const NFSForm = ({ form }: Props) => {
 				render={({ field }) => (
 					<FormItem>
 						<FormLabel>Version</FormLabel>
-						<Select onValueChange={field.onChange} defaultValue="4.1">
+						<Select onValueChange={field.onChange} value={field.value}>
 							<FormControl>
 								<SelectTrigger>
 									<SelectValue placeholder="Select NFS version" />


### PR DESCRIPTION
This pull request makes a small update to the `NFSForm` component to improve how the selected NFS version is managed. 

Instead of always defaulting to version "4.1", the component now uses the current value from the form state, ensuring the selected version reflects user input or existing data.

Fixes: https://github.com/nicotsx/zerobyte/issues/328

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the Version field in the NFS form to properly reflect and update with form changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h2>Greptile Overview</h2>

### Greptile Summary

This PR fixes a bug in the NFSForm component where the Version select field was using `defaultValue="4.1"` instead of being properly controlled with `value={field.value}`.

The issue manifested when editing existing NFS volumes - the version selector would always display "4.1" regardless of the actual saved version value. With this change, the Select component now correctly reflects the current form state, whether creating a new volume (defaulting to "4.1" via the FormField's `defaultValue` prop) or editing an existing one (showing the stored version).

The fix aligns the NFS version field with the identical pattern already used for the SMB version field (line 85 in smb-form.tsx), ensuring consistent controlled component behavior across all volume form selects.

### Confidence Score: 5/5

- This is a safe, straightforward bug fix that properly implements controlled component behavior for a Select field.
- The change is minimal, well-scoped, and follows the exact same pattern already used successfully in the SMB form (line 85). The FormField still has `defaultValue="4.1"` to handle initial values for new volumes, while the Select now properly reflects the form state via `value={field.value}`. This is the standard react-hook-form pattern for controlled Select components. No breaking changes, no edge cases introduced.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->