### PR TITLE
increase name length limit from 32 to 128 characters in backup schedules

### DIFF
--- a/app/client/modules/backups/components/create-schedule-form.tsx
+++ b/app/client/modules/backups/components/create-schedule-form.tsx
@@ -29,7 +29,7 @@ import type { BackupSchedule, Volume } from "~/client/lib/types";
 import { deepClean } from "~/utils/object";
 
 const internalFormSchema = type({
-	name: "1 <= string <= 32",
+	name: "1 <= string <= 128",
 	repositoryId: "string",
 	excludePatternsText: "string?",
 	excludeIfPresentText: "string?",

--- a/app/server/modules/backups/backups.dto.ts
+++ b/app/server/modules/backups/backups.dto.ts
@@ -124,7 +124,7 @@ export const getBackupScheduleForVolumeDto = describeRoute({
  * Create a new backup schedule
  */
 export const createBackupScheduleBody = type({
-	name: "1 <= string <= 32",
+	name: "1 <= string <= 128",
 	volumeId: "number",
 	repositoryId: "string",
 	enabled: "boolean",
@@ -163,7 +163,7 @@ export const createBackupScheduleDto = describeRoute({
  * Update a backup schedule
  */
 export const updateBackupScheduleBody = type({
-	name: "(1 <= string <= 32)?",
+	name: "(1 <= string <= 128)?",
 	repositoryId: "string",
 	enabled: "boolean?",
 	cronExpression: "string",


### PR DESCRIPTION
This pull request increases the allowed length for the `name` field in backup schedule forms and related API DTOs from 32 to 128 characters. This change ensures users can specify longer, more descriptive names for backup schedules throughout the application.

**Form and API validation updates:**

* Increased the maximum length of the `name` field from 32 to 128 characters in the client-side form schema in `create-schedule-form.tsx`.
* Updated the `name` field length constraint in the `createBackupScheduleBody` and `updateBackupScheduleBody` API DTOs in `backups.dto.ts` to allow up to 128 characters.


Closes: https://github.com/nicotsx/zerobyte/issues/306

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h2>Greptile Overview</h2>

### Greptile Summary

This PR increases the maximum allowed length for backup schedule names from 32 to 128 characters. The change is implemented consistently across all validation layers:

**Client-side validation:**
- Updated form schema in `create-schedule-form.tsx` (used for both create and edit operations)

**Server-side validation:**
- Updated `createBackupScheduleBody` DTO for the POST endpoint
- Updated `updateBackupScheduleBody` DTO for the PATCH endpoint

**Database impact:**
The database schema already uses SQLite's `TEXT` type without length constraints, so no migration is required.

**Architecture fit:**
This change follows the project's validation pattern using ArkType schemas at both the client and server layers. The response DTOs correctly remain unchanged as they only define the shape of returned data, not input validation constraints.

### Confidence Score: 5/5

- This PR is safe to merge with no issues identified
- The change is straightforward and correctly implemented. All three validation points (client form, create DTO, update DTO) have been updated consistently. The database schema already supports text of any length. No breaking changes, no edge cases, and no missing updates detected.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->