### PR TITLE
remove bun cache from production image to optimize the space

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -98,7 +98,7 @@ ENV NODE_ENV="production"
 WORKDIR /app
 
 COPY --from=builder /app/package.json ./
-RUN bun install --production --frozen-lockfile
+RUN bun install --production --frozen-lockfile && rm -rf $HOME/.bun/install/cache
 
 COPY --from=deps /deps/restic /usr/local/bin/restic
 COPY --from=deps /deps/rclone /usr/local/bin/rclone


### PR DESCRIPTION
resolve https://github.com/nicotsx/zerobyte/issues/379

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized Docker image size by streamlining the build process and removing unnecessary cache artifacts after dependency installation, resulting in faster and more efficient deployments with reduced resource consumption.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->