### PR TITLE
Description:Added support for virtual-host style access for Huawei Cloud OBS. This is achieved by introducing the AWS_S3_BUCKET_LOOKUP environment variable and adding the s3.bucket-lookup=dns option to the parameters.

### DIFF
--- a/app/server/utils/restic.ts
+++ b/app/server/utils/restic.ts
@@ -133,6 +133,11 @@ export const buildEnv = async (config: RepositoryConfig, organizationId: string)
 		case "s3":
 			env.AWS_ACCESS_KEY_ID = await cryptoUtils.resolveSecret(config.accessKeyId);
 			env.AWS_SECRET_ACCESS_KEY = await cryptoUtils.resolveSecret(config.secretAccessKey);
+
+			// Huawei OBS requires virtual-hosted style access
+			if (config.endpoint.includes("myhuaweicloud")) {
+				env.AWS_S3_BUCKET_LOOKUP = "dns";
+			}
 			break;
 		case "r2":
 			env.AWS_ACCESS_KEY_ID = await cryptoUtils.resolveSecret(config.accessKeyId);
@@ -919,6 +924,10 @@ export const addCommonArgs = (
 
 	if (env._SFTP_SSH_ARGS) {
 		args.push("-o", `sftp.args=${env._SFTP_SSH_ARGS}`);
+	}
+
+	if (env.AWS_S3_BUCKET_LOOKUP === "dns") {
+		args.push("-o", "s3.bucket-lookup=dns");
 	}
 
 	if (env._INSECURE_TLS === "true") {


### PR DESCRIPTION
Added support for virtual-host style access for Huawei Cloud OBS. This is achieved by introducing the AWS_S3_BUCKET_LOOKUP environment variable and adding the s3.bucket-lookup=dns option to the parameters.

Changes:

Set AWS_S3_BUCKET_LOOKUP environment variable.
Included s3.bucket-lookup=dns in the S3 configuration options to ensure compatibility with Huawei OBS DNS-based bucket addressing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Huawei OBS as a cloud storage backup destination. The system now automatically detects Huawei OBS endpoints and applies virtual-hosted style bucket lookup configuration, enabling users to perform seamless backups to Huawei cloud storage without requiring any additional manual setup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->