### PR TITLE
feat: add support for sending notifications to Telegram group topics

### DIFF
--- a/app/client/modules/notifications/components/create-notification-form.tsx
+++ b/app/client/modules/notifications/components/create-notification-form.tsx
@@ -86,6 +86,7 @@ const defaultValuesForType = {
 		type: "telegram" as const,
 		botToken: "",
 		chatId: "",
+		threadId: "",
 	},
 	generic: {
 		type: "generic" as const,

--- a/app/client/modules/notifications/components/notification-forms/telegram-form.tsx
+++ b/app/client/modules/notifications/components/notification-forms/telegram-form.tsx
@@ -39,6 +39,20 @@ export const TelegramForm = ({ form }: Props) => {
 					</FormItem>
 				)}
 			/>
+			<FormField
+				control={form.control}
+				name="threadId"
+				render={({ field }) => (
+					<FormItem>
+						<FormLabel>Thread ID (Optional)</FormLabel>
+						<FormControl>
+							<Input {...field} placeholder="3" />
+						</FormControl>
+						<FormDescription>Telegram Group Topic ID to send notifications to.</FormDescription>
+						<FormMessage />
+					</FormItem>
+				)}
+			/>
 		</>
 	);
 };

--- a/app/schemas/notifications.ts
+++ b/app/schemas/notifications.ts
@@ -71,6 +71,7 @@ export const telegramNotificationConfigSchema = type({
 	type: "'telegram'",
 	botToken: "string",
 	chatId: "string",
+	threadId: "string?",
 });
 
 export const genericNotificationConfigSchema = type({

--- a/app/server/modules/notifications/builders/telegram.ts
+++ b/app/server/modules/notifications/builders/telegram.ts
@@ -1,5 +1,9 @@
 import type { NotificationConfig } from "~/schemas/notifications";
 
 export const buildTelegramShoutrrrUrl = (config: Extract<NotificationConfig, { type: "telegram" }>) => {
-	return `telegram://${config.botToken}@telegram?channels=${config.chatId}`;
+	let shoutrrrUrl =  `telegram://${config.botToken}@telegram?channels=${config.chatId}`;
+	if (config.threadId) {
+		shoutrrrUrl += `:${config.threadId}`;
+	}
+	return shoutrrrUrl;
 };


### PR DESCRIPTION
Add support to send notifications to specific topic within a group rather than just the general chat. #357 

**Changes:**
- Added a `Thread ID` field to the Telegram form when creating a notification destination.
- Added the `threadId` type to the `telegramNotificationConfigSchema`.
- Updated the Telegram Shoutrrr URL to support routing notifications to specific thread IDs

<img width="557" height="606" alt="image" src="https://github.com/user-attachments/assets/1e279dcb-e892-4d01-91f9-0749c2325377" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added optional Thread ID field for Telegram notifications, allowing users to specify which Telegram Group Topic to send notification messages to.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->