### PR TITLE
feat(pushover): add support for all priority levels

### DIFF
--- a/app/client/api-client/types.gen.ts
+++ b/app/client/api-client/types.gen.ts
@@ -2970,7 +2970,7 @@ export type GetScheduleNotificationsResponses = {
 			config:
 				| {
 						apiToken: string;
-						priority: -1 | 0 | 1;
+						priority: -1 | -2 | 0 | 1 | 2;
 						type: "pushover";
 						userKey: string;
 						devices?: string;
@@ -3080,7 +3080,7 @@ export type UpdateScheduleNotificationsResponses = {
 			config:
 				| {
 						apiToken: string;
-						priority: -1 | 0 | 1;
+						priority: -1 | -2 | 0 | 1 | 2;
 						type: "pushover";
 						userKey: string;
 						devices?: string;
@@ -3655,7 +3655,7 @@ export type ListNotificationDestinationsResponses = {
 		config:
 			| {
 					apiToken: string;
-					priority: -1 | 0 | 1;
+					priority: -1 | -2 | 0 | 1 | 2;
 					type: "pushover";
 					userKey: string;
 					devices?: string;
@@ -3736,7 +3736,7 @@ export type CreateNotificationDestinationData = {
 		config:
 			| {
 					apiToken: string;
-					priority: -1 | 0 | 1;
+					priority: -1 | -2 | 0 | 1 | 2;
 					type: "pushover";
 					userKey: string;
 					devices?: string;
@@ -3815,7 +3815,7 @@ export type CreateNotificationDestinationResponses = {
 		config:
 			| {
 					apiToken: string;
-					priority: -1 | 0 | 1;
+					priority: -1 | -2 | 0 | 1 | 2;
 					type: "pushover";
 					userKey: string;
 					devices?: string;
@@ -3943,7 +3943,7 @@ export type GetNotificationDestinationResponses = {
 		config:
 			| {
 					apiToken: string;
-					priority: -1 | 0 | 1;
+					priority: -1 | -2 | 0 | 1 | 2;
 					type: "pushover";
 					userKey: string;
 					devices?: string;
@@ -4024,7 +4024,7 @@ export type UpdateNotificationDestinationData = {
 		config?:
 			| {
 					apiToken: string;
-					priority: -1 | 0 | 1;
+					priority: -1 | -2 | 0 | 1 | 2;
 					type: "pushover";
 					userKey: string;
 					devices?: string;
@@ -4113,7 +4113,7 @@ export type UpdateNotificationDestinationResponses = {
 		config:
 			| {
 					apiToken: string;
-					priority: -1 | 0 | 1;
+					priority: -1 | -2 | 0 | 1 | 2;
 					type: "pushover";
 					userKey: string;
 					devices?: string;

--- a/app/client/modules/notifications/components/notification-forms/pushover-form.tsx
+++ b/app/client/modules/notifications/components/notification-forms/pushover-form.tsx
@@ -71,9 +71,11 @@ export const PushoverForm = ({ form }: Props) => {
 								</SelectTrigger>
 							</FormControl>
 							<SelectContent>
+								<SelectItem value="-2">Lowest (-2)</SelectItem>
 								<SelectItem value="-1">Low (-1)</SelectItem>
 								<SelectItem value="0">Normal (0)</SelectItem>
 								<SelectItem value="1">High (1)</SelectItem>
+								<SelectItem value="2">Emergency (2)</SelectItem>
 							</SelectContent>
 						</Select>
 						<FormDescription>Message priority level.</FormDescription>

--- a/app/schemas/notifications.ts
+++ b/app/schemas/notifications.ts
@@ -64,7 +64,7 @@ export const pushoverNotificationConfigSchema = type({
 	userKey: "string",
 	apiToken: "string",
 	devices: "string?",
-	priority: "-1 | 0 | 1",
+	priority: "-2 | -1 | 0 | 1 | 2",
 });
 
 export const telegramNotificationConfigSchema = type({


### PR DESCRIPTION
## Summary

Pushover supports 5 priority levels but the notification form only had 3 options. This adds the missing priority levels:

- **Lowest (-2)** - No notification/alert, just appears in the app
- **Emergency (2)** - Repeats until acknowledged by the user

## Changes

- Updated the priority dropdown in the Pushover form to include all 5 levels
- Updated the schema validation to accept the full range (-2 to 2)

## Testing

- Verified the form displays all priority options correctly
- Confirmed schema validates the new priority values

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added two new priority levels to Pushover notifications: Lowest (-2) and Emergency (2). This enhancement expands the available notification priority configuration options, allowing for greater flexibility in alert routing and overall notification handling. Users can now implement more nuanced prioritization strategies based on specific urgency levels and various alert type requirements.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->