### PR TITLE
fix(backup-card): dot invisible if volume name too long

### DIFF
--- a/app/client/modules/backups/components/backup-card.tsx
+++ b/app/client/modules/backups/components/backup-card.tsx
@@ -21,11 +21,11 @@ export const BackupCard = ({ schedule }: { schedule: BackupSchedule }) => {
 							isInProgress={schedule.lastBackupStatus === "in_progress"}
 						/>
 					</div>
-					<CardDescription className="ml-0.5 flex items-center gap-2 text-xs">
-						<HardDrive className="h-3.5 w-3.5" />
+					<CardDescription className="ml-0.5 flex items-center gap-2 text-xs min-w-0">
+						<HardDrive className="h-3.5 w-3.5 shrink-0" />
 						<span className="truncate">{schedule.volume.name}</span>
-						<span className="text-muted-foreground">→</span>
-						<Database className="h-3.5 w-3.5 text-strong-accent" />
+						<span className="text-muted-foreground shrink-0">→</span>
+						<Database className="h-3.5 w-3.5 text-strong-accent shrink-0" />
 						<span className="truncate text-strong-accent">{schedule.repository.name}</span>
 					</CardDescription>
 				</CardHeader>


### PR DESCRIPTION
Closes #316

<img width="526" height="247" alt="image" src="https://github.com/user-attachments/assets/9e496808-a27b-40af-8a39-d4df4686165f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed backup card layout to prevent text and icons from being improperly squeezed, ensuring volume names and repository information display correctly.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->