### PR TITLE
feat: custom rclone conf dir env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,16 +89,17 @@ Zerobyte can be customized using environment variables. Below are the available 
 
 ### Environment Variables
 
-| Variable              | Description                                                                                                                               | Default    |
-| :-------------------- | :---------------------------------------------------------------------------------------------------------------------------------------- | :--------- |
-| `BASE_URL`            | **Required.** The base URL of your Zerobyte instance (e.g., `https://zerobyte.example.com`). See [Authentication](#authentication) below. | (none)     |
-| `APP_SECRET`          | **Required.** A random secret key (32+ chars) used to encrypt sensitive data in the database. Generate with `openssl rand -hex 32`.       | (none)     |
-| `PORT`                | The port the web interface and API will listen on.                                                                                        | `4096`     |
-| `RESTIC_HOSTNAME`     | The hostname used by Restic when creating snapshots. Automatically detected if a custom hostname is set in Docker.                        | `zerobyte` |
-| `TZ`                  | Timezone for the container (e.g., `Europe/Paris`). **Crucial for accurate backup scheduling.**                                            | `UTC`      |
-| `TRUSTED_ORIGINS`     | Comma-separated list of extra trusted origins for CORS (e.g., `http://localhost:3000,http://example.com`).                                | (none)     |
-| `LOG_LEVEL`           | Logging verbosity. Options: `debug`, `info`, `warn`, `error`.                                                                             | `info`     |
-| `SERVER_IDLE_TIMEOUT` | Idle timeout for the server in seconds.                                                                                                   | `60`       |
+| Variable              | Description                                                                                                                               | Default                |
+| :-------------------- | :---------------------------------------------------------------------------------------------------------------------------------------- | :--------------------- |
+| `BASE_URL`            | **Required.** The base URL of your Zerobyte instance (e.g., `https://zerobyte.example.com`). See [Authentication](#authentication) below. | (none)                 |
+| `APP_SECRET`          | **Required.** A random secret key (32+ chars) used to encrypt sensitive data in the database. Generate with `openssl rand -hex 32`.       | (none)                 |
+| `PORT`                | The port the web interface and API will listen on.                                                                                        | `4096`                 |
+| `RESTIC_HOSTNAME`     | The hostname used by Restic when creating snapshots. Automatically detected if a custom hostname is set in Docker.                        | `zerobyte`             |
+| `TZ`                  | Timezone for the container (e.g., `Europe/Paris`). **Crucial for accurate backup scheduling.**                                            | `UTC`                  |
+| `TRUSTED_ORIGINS`     | Comma-separated list of extra trusted origins for CORS (e.g., `http://localhost:3000,http://example.com`).                                | (none)                 |
+| `LOG_LEVEL`           | Logging verbosity. Options: `debug`, `info`, `warn`, `error`.                                                                             | `info`                 |
+| `SERVER_IDLE_TIMEOUT` | Idle timeout for the server in seconds.                                                                                                   | `60`                   |
+| `RCLONE_CONFIG_DIR`   | Path to the rclone config directory inside the container. Change this if running as a non-root user.                                      | `/root/.config/rclone` |
 
 ### Secret References
 
@@ -250,9 +251,10 @@ Zerobyte can use [rclone](https://rclone.org/) to support 40+ cloud storage prov
    ```
 
    > **Note for non-root users:** If your container runs as a different user (e.g., TrueNAS apps), mount your config to the appropriate location and set `RCLONE_CONF_DIR`:
+   >
    > ```yaml
    > environment:
-   >   - RCLONE_CONF_DIR=/home/appuser/.config/rclone
+   >   - RCLONE_CONFIG_DIR=/home/appuser/.config/rclone
    > volumes:
    >   - ~/.config/rclone:/home/appuser/.config/rclone:ro
    > ```
@@ -265,9 +267,9 @@ Zerobyte can use [rclone](https://rclone.org/) to support 40+ cloud storage prov
    ```
 
 6. **Create a repository** in Zerobyte:
-    - Select "rclone" as the repository type
-    - Choose your configured remote from the dropdown
-    - Specify the path within your remote (e.g., `backups/zerobyte`)
+   - Select "rclone" as the repository type
+   - Choose your configured remote from the dropdown
+   - Specify the path within your remote (e.g., `backups/zerobyte`)
 
 For a complete list of supported providers, see the [rclone documentation](https://rclone.org/).
 

--- a/app/server/core/capabilities.ts
+++ b/app/server/core/capabilities.ts
@@ -1,5 +1,5 @@
 import * as fs from "node:fs/promises";
-import { RCLONE_CONF_DIR } from "./constants";
+import { RCLONE_CONFIG_DIR } from "./constants";
 import { logger } from "../utils/logger";
 
 export type SystemCapabilities = {
@@ -39,10 +39,10 @@ async function detectCapabilities(): Promise<SystemCapabilities> {
  */
 async function detectRclone(): Promise<boolean> {
 	try {
-		await fs.access(RCLONE_CONF_DIR);
+		await fs.access(RCLONE_CONFIG_DIR);
 
 		// Make sure the folder is not empty
-		const files = await fs.readdir(RCLONE_CONF_DIR);
+		const files = await fs.readdir(RCLONE_CONFIG_DIR);
 		if (files.length === 0) {
 			throw new Error("rclone config directory is empty");
 		}
@@ -51,7 +51,7 @@ async function detectRclone(): Promise<boolean> {
 		return true;
 	} catch (_) {
 		logger.warn(
-			`rclone capability: disabled. ` + `To enable: mount rclone config at ${RCLONE_CONF_DIR} in docker-compose.yml`,
+			`rclone capability: disabled. ` + `To enable: mount rclone config at ${RCLONE_CONFIG_DIR} in docker-compose.yml`,
 		);
 		return false;
 	}

--- a/app/server/core/constants.ts
+++ b/app/server/core/constants.ts
@@ -8,6 +8,6 @@ export const RESTIC_CACHE_DIR = process.env.RESTIC_CACHE_DIR || "/var/lib/zeroby
 export const DATABASE_URL = process.env.DATABASE_URL || "/var/lib/zerobyte/data/zerobyte.db";
 export const RESTIC_PASS_FILE = process.env.RESTIC_PASS_FILE || "/var/lib/zerobyte/data/restic.pass";
 
-export const RCLONE_CONF_DIR = process.env.RCLONE_CONF_DIR || "/root/.config/rclone";
+export const RCLONE_CONFIG_DIR = process.env.RCLONE_CONFIG_DIR || "/root/.config/rclone";
 
 export const DEFAULT_EXCLUDES = [DATABASE_URL, RESTIC_PASS_FILE, REPOSITORY_BASE];

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,17 +10,20 @@ services:
       - /dev/fuse:/dev/fuse
     cap_add:
       - SYS_ADMIN
+    env_file:
+      - .env.local
     environment:
       - NODE_ENV=development
-      - APP_SECRET=94bad4678ce84a60b9789bd2114a6bf780aeb38df426f7352c941c66e25d5c2b
-      - BASE_URL=http://localhost:4096
+      - APP_SECRET=${APP_SECRET}
+      - BASE_URL=${BASE_URL:http://localhost:3000}
     ports:
-      - "4096:4096"
+      - "3000:3000"
     volumes:
       - /etc/localtime:/etc/localtime:ro
       - /var/lib/zerobyte:/var/lib/zerobyte
       - ./app:/app/app
       - ~/.config/rclone:/root/.config/rclone
+      - ./tmp/:/test-data
 
   zerobyte-prod:
     # image: ghcr.io/nicotsx/zerobyte:v0.22.0


### PR DESCRIPTION
Closes #238

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Rclone configuration directory is now configurable via RCLONE_CONF_DIR environment variable, replacing hardcoded paths.

* **Documentation**
  * Added RCLONE_CONF_DIR to the environment variables table.
  * Added setup guidance for non-root users with examples showing how to mount and reference rclone configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->