### PR TITLE
fix: add restic --host to repo init command

### DIFF
--- a/app/server/utils/restic.ts
+++ b/app/server/utils/restic.ts
@@ -252,6 +252,8 @@ const init = async (config: RepositoryConfig, organizationId: string, options?: 
 	const env = await buildEnv(config, organizationId);
 
 	const args = ["init", "--repo", repoUrl];
+
+	args.push("--host", appConfig.resticHostname);
 	addCommonArgs(args, env, config);
 
 	const res = await exec({ command: "restic", args, env, timeout: options?.timeoutMs ?? 20000 });
@@ -303,9 +305,7 @@ const backup = async (
 		args.push("--one-file-system");
 	}
 
-	if (appConfig.resticHostname) {
-		args.push("--host", appConfig.resticHostname);
-	}
+	args.push("--host", appConfig.resticHostname);
 
 	if (options?.tags && options.tags.length > 0) {
 		for (const tag of options.tags) {


### PR DESCRIPTION
Closes #456


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency in restic backup command configuration to ensure the host argument is reliably included in all backup and initialization operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->