### PR TITLE
fix(file-tree): display load more if root folder has 500+ items

### DIFF
--- a/app/client/components/__test__/file-tree.test.tsx
+++ b/app/client/components/__test__/file-tree.test.tsx
@@ -15,7 +15,12 @@ describe("FileTree Pagination", () => {
 			<FileTree
 				files={testFiles}
 				expandedFolders={new Set(["/root"])}
-				getFolderPagination={() => ({ hasMore: true, isLoadingMore: false })}
+				getFolderPagination={(path) => {
+					if (path === "/root") {
+						return { hasMore: true, isLoadingMore: false };
+					}
+					return { hasMore: false, isLoadingMore: false };
+				}}
 			/>,
 		);
 
@@ -67,11 +72,37 @@ describe("FileTree Pagination", () => {
 			<FileTree
 				files={testFiles}
 				expandedFolders={new Set(["/root"])}
-				getFolderPagination={() => ({ hasMore: true, isLoadingMore: true })}
+				getFolderPagination={(path) => {
+					if (path === "/root") {
+						return { hasMore: true, isLoadingMore: true };
+					}
+					return { hasMore: false, isLoadingMore: false };
+				}}
 			/>,
 		);
 
 		expect(screen.getByText("Loading more...")).toBeTruthy();
+	});
+
+	test("shows load more button for root-level files when root has more", () => {
+		const rootFiles: FileEntry[] = [
+			{ name: "file1", path: "/file1", type: "file" },
+			{ name: "file2", path: "/file2", type: "file" },
+		];
+
+		render(
+			<FileTree
+				files={rootFiles}
+				getFolderPagination={(path) => {
+					if (path === "/") {
+						return { hasMore: true, isLoadingMore: false };
+					}
+					return { hasMore: false, isLoadingMore: false };
+				}}
+			/>,
+		);
+
+		expect(screen.getByText("Load more files")).toBeTruthy();
 	});
 
 	test("load more button appears for nested folders with hasMore", () => {
@@ -103,7 +134,12 @@ describe("FileTree Pagination", () => {
 			<FileTree
 				files={testFiles}
 				expandedFolders={new Set([])}
-				getFolderPagination={() => ({ hasMore: true, isLoadingMore: false })}
+				getFolderPagination={(path) => {
+					if (path === "/root") {
+						return { hasMore: true, isLoadingMore: false };
+					}
+					return { hasMore: false, isLoadingMore: false };
+				}}
 			/>,
 		);
 

--- a/app/client/components/file-tree.tsx
+++ b/app/client/components/file-tree.tsx
@@ -316,13 +316,10 @@ export const FileTree = memo((props: Props) => {
 		for (let i = 0; i < filteredFileList.length; i++) {
 			const item = filteredFileList[i];
 			const parentPath = item.fullPath.slice(0, item.fullPath.lastIndexOf("/")) || "/";
-
-			if (parentPath !== "/") {
-				const pagination = getFolderPagination?.(parentPath);
-				if (pagination?.hasMore && !collapsedFolders.has(parentPath)) {
-					// Update the last index for this parent
-					map.set(parentPath, i);
-				}
+			const pagination = getFolderPagination?.(parentPath);
+			if (pagination?.hasMore && !collapsedFolders.has(parentPath)) {
+				// Update the last index for this parent
+				map.set(parentPath, i);
 			}
 		}
 


### PR DESCRIPTION
Close #518

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed pagination handling to now include root-level folders, enabling "Load more" functionality at the root level when additional files are available.

* **Tests**
  * Added comprehensive test coverage for root-level pagination and loading state scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->