### PR TITLE
fix: add DisableTLS param if server is http

### DIFF
--- a/app/server/modules/notifications/builders/gotify.ts
+++ b/app/server/modules/notifications/builders/gotify.ts
@@ -5,11 +5,22 @@ export const buildGotifyShoutrrrUrl = (config: Extract<NotificationConfig, { typ
 	const hostname = url.hostname;
 	const port = url.port ? `:${url.port}` : "";
 	const path = config.path ? `/${config.path.replace(/^\/+|\/+$/g, "")}` : "";
+	const disableTLS = url.protocol === "http:";
 
 	let shoutrrrUrl = `gotify://${hostname}${port}${path}/${config.token}`;
 
+	const params = new URLSearchParams();
+
+	if (disableTLS) {
+		params.set("DisableTLS", "true");
+	}
+
 	if (config.priority !== undefined) {
-		shoutrrrUrl += `?priority=${config.priority}`;
+		params.set("priority", String(config.priority));
+	}
+
+	if (params.toString()) {
+		shoutrrrUrl += `?${params.toString()}`;
 	}
 
 	return shoutrrrUrl;


### PR DESCRIPTION
Closes #561

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved Gotify notification configuration to correctly detect and handle HTTP protocol connections without TLS encryption.
  * Enhanced query parameter handling for notification settings, including improved priority parameter support with more reliable transmission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->