### PR TITLE
fix(repo): add a custom key after creation with the configured hostname

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,7 @@
 - If you realize an automated migration is incorrect, make sure to remove all the associated entries from the `_journal.json` and the newly created files located in `app/drizzle/` before re-generating the migration
 - The dev server is running at http://localhost:3000. Username is `admin` and password is `password`
 - The repo is https://github.com/nicotsx/zerobyte
+- If you need to run a specific restic command on a repository, you can open and use the dev panel with `Meta+Shift+D`
 
 ## Project Overview
 


### PR DESCRIPTION
Closes #456

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added information about running restic commands via the dev panel using the Meta+Shift+D keyboard shortcut.

* **New Features**
  * Repository initialization now includes automatic key addition when configured. Key addition failures do not block repository setup completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->