### PR TITLE
feat(backups): add custom restic params to backup schedules

### DIFF
--- a/app/client/api-client/types.gen.ts
+++ b/app/client/api-client/types.gen.ts
@@ -2202,6 +2202,7 @@ export type ListBackupSchedulesResponses = {
 		name: string;
 		nextBackupAt: number | null;
 		oneFileSystem: boolean;
+		customResticParams: Array<string> | null;
 		repository: {
 			compressionMode: "auto" | "max" | "off" | null;
 			config:
@@ -2485,6 +2486,7 @@ export type CreateBackupScheduleData = {
 		excludePatterns?: Array<string>;
 		includePatterns?: Array<string>;
 		oneFileSystem?: boolean;
+		customResticParams?: Array<string>;
 		retentionPolicy?: {
 			keepDaily?: number;
 			keepHourly?: number;
@@ -2519,6 +2521,7 @@ export type CreateBackupScheduleResponses = {
 		name: string;
 		nextBackupAt: number | null;
 		oneFileSystem: boolean;
+		customResticParams: Array<string> | null;
 		repositoryId: string;
 		retentionPolicy: {
 			keepDaily?: number;
@@ -2584,6 +2587,7 @@ export type GetBackupScheduleResponses = {
 		name: string;
 		nextBackupAt: number | null;
 		oneFileSystem: boolean;
+		customResticParams: Array<string> | null;
 		repository: {
 			compressionMode: "auto" | "max" | "off" | null;
 			config:
@@ -2866,6 +2870,7 @@ export type UpdateBackupScheduleData = {
 		includePatterns?: Array<string>;
 		name?: string;
 		oneFileSystem?: boolean;
+		customResticParams?: Array<string>;
 		retentionPolicy?: {
 			keepDaily?: number;
 			keepHourly?: number;
@@ -2902,6 +2907,7 @@ export type UpdateBackupScheduleResponses = {
 		name: string;
 		nextBackupAt: number | null;
 		oneFileSystem: boolean;
+		customResticParams: Array<string> | null;
 		repositoryId: string;
 		retentionPolicy: {
 			keepDaily?: number;
@@ -2947,6 +2953,7 @@ export type GetBackupScheduleForVolumeResponses = {
 		name: string;
 		nextBackupAt: number | null;
 		oneFileSystem: boolean;
+		customResticParams: Array<string> | null;
 		repository: {
 			compressionMode: "auto" | "max" | "off" | null;
 			config:

--- a/app/client/modules/backups/components/create-schedule-form/advanced-section.tsx
+++ b/app/client/modules/backups/components/create-schedule-form/advanced-section.tsx
@@ -1,0 +1,35 @@
+import { FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from "~/client/components/ui/form";
+import { Textarea } from "~/client/components/ui/textarea";
+import type { UseFormReturn } from "react-hook-form";
+import type { InternalFormValues } from "./types";
+
+type AdvancedSectionProps = {
+	form: UseFormReturn<InternalFormValues>;
+};
+
+export const AdvancedSection = ({ form }: AdvancedSectionProps) => {
+	return (
+		<FormField
+			control={form.control}
+			name="customResticParamsText"
+			render={({ field }) => (
+				<FormItem>
+					<FormLabel>Custom restic parameters</FormLabel>
+					<FormControl>
+						<Textarea
+							{...field}
+							placeholder="--iexclude-larger-than 500M&#10;--no-scan&#10;--read-concurrency 8"
+							className="font-mono text-sm min-h-24"
+						/>
+					</FormControl>
+					<FormDescription>
+						Advanced: enter one restic flag per line (e.g.{" "}
+						<code className="bg-muted px-1 rounded">--iexclude-larger-than 500M</code>). These are appended to the
+						backup command as-is.
+					</FormDescription>
+					<FormMessage />
+				</FormItem>
+			)}
+		/>
+	);
+};

--- a/app/client/modules/backups/components/create-schedule-form/index.tsx
+++ b/app/client/modules/backups/components/create-schedule-form/index.tsx
@@ -5,6 +5,7 @@ import { useScrollToFormError } from "~/client/hooks/use-scroll-to-form-error";
 import { Form } from "~/client/components/ui/form";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "~/client/components/ui/card";
 import type { BackupSchedule, Volume } from "~/client/lib/types";
+import { AdvancedSection } from "./advanced-section";
 import { BasicInfoSection } from "./basic-info-section";
 import { ExcludeSection } from "./exclude-section";
 import { FrequencySection } from "./frequency-section";
@@ -39,6 +40,7 @@ export const CreateScheduleForm = ({ initialValues, formId, onSubmit, volume }: 
 				excludePatternsText,
 				excludeIfPresentText,
 				includePatternsText,
+				customResticParamsText,
 				includePatterns: fileBrowserPatterns,
 				cronExpression,
 				...rest
@@ -65,12 +67,20 @@ export const CreateScheduleForm = ({ initialValues, formId, onSubmit, volume }: 
 				: [];
 			const includePatterns = [...(fileBrowserPatterns || []), ...textPatterns];
 
+			const customResticParams = customResticParamsText
+				? customResticParamsText
+						.split("\n")
+						.map((p) => p.trim())
+						.filter(Boolean)
+				: [];
+
 			onSubmit({
 				...rest,
 				cronExpression,
 				includePatterns: includePatterns.length > 0 ? includePatterns : [],
 				excludePatterns,
 				excludeIfPresent,
+				customResticParams,
 			});
 		},
 		[onSubmit],
@@ -162,6 +172,18 @@ export const CreateScheduleForm = ({ initialValues, formId, onSubmit, volume }: 
 						</CardHeader>
 						<CardContent className="grid gap-4 @medium:grid-cols-2">
 							<RetentionSection form={form} />
+						</CardContent>
+					</Card>
+
+					<Card className="min-w-0">
+						<CardHeader>
+							<CardTitle>Advanced</CardTitle>
+							<CardDescription>
+								Pass additional flags directly to the restic backup command. Use with caution.
+							</CardDescription>
+						</CardHeader>
+						<CardContent>
+							<AdvancedSection form={form} />
 						</CardContent>
 					</Card>
 				</div>

--- a/app/client/modules/backups/components/create-schedule-form/types.ts
+++ b/app/client/modules/backups/components/create-schedule-form/types.ts
@@ -20,6 +20,7 @@ export const internalFormSchema = type({
 	keepMonthly: "number?",
 	keepYearly: "number?",
 	oneFileSystem: "boolean?",
+	customResticParamsText: "string?",
 });
 
 export const cleanSchema = type.pipe((d) => internalFormSchema(deepClean(d)));
@@ -38,8 +39,9 @@ export type InternalFormValues = typeof internalFormSchema.infer;
 
 export type BackupScheduleFormValues = Omit<
 	InternalFormValues,
-	"excludePatternsText" | "excludeIfPresentText" | "includePatternsText"
+	"excludePatternsText" | "excludeIfPresentText" | "includePatternsText" | "customResticParamsText"
 > & {
 	excludePatterns?: string[];
 	excludeIfPresent?: string[];
+	customResticParams?: string[];
 };

--- a/app/client/modules/backups/components/create-schedule-form/utils.ts
+++ b/app/client/modules/backups/components/create-schedule-form/utils.ts
@@ -22,6 +22,7 @@ export const backupScheduleToFormValues = (schedule?: BackupSchedule): InternalF
 		excludePatternsText: schedule.excludePatterns?.join("\n") || undefined,
 		excludeIfPresentText: schedule.excludeIfPresent?.join("\n") || undefined,
 		oneFileSystem: schedule.oneFileSystem ?? false,
+		customResticParamsText: schedule.customResticParams?.join("\n") ?? "",
 		...cronValues,
 		...schedule.retentionPolicy,
 	};

--- a/app/client/modules/backups/routes/backup-details.tsx
+++ b/app/client/modules/backups/routes/backup-details.tsx
@@ -181,6 +181,7 @@ export function ScheduleDetailsPage(props: Props) {
 				excludePatterns: formValues.excludePatterns,
 				excludeIfPresent: formValues.excludeIfPresent,
 				oneFileSystem: formValues.oneFileSystem,
+				customResticParams: formValues.customResticParams,
 			},
 		});
 	};

--- a/app/client/modules/backups/routes/create-backup.tsx
+++ b/app/client/modules/backups/routes/create-backup.tsx
@@ -73,6 +73,7 @@ export function CreateBackupPage() {
 				excludePatterns: formValues.excludePatterns,
 				excludeIfPresent: formValues.excludeIfPresent,
 				oneFileSystem: formValues.oneFileSystem,
+				customResticParams: formValues.customResticParams,
 			},
 		});
 	};

--- a/app/drizzle/20260227000000_add-custom-restic-params/migration.sql
+++ b/app/drizzle/20260227000000_add-custom-restic-params/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `backup_schedules_table` ADD `custom_restic_params` text DEFAULT '[]';

--- a/app/drizzle/20260227000000_add-custom-restic-params/snapshot.json
+++ b/app/drizzle/20260227000000_add-custom-restic-params/snapshot.json
@@ -1,0 +1,2045 @@
+{
+	"version": "7",
+	"dialect": "sqlite",
+	"id": "38a5fef6-d38e-4bf0-b9ab-0723db3741da",
+	"prevIds": ["3a308c54-d950-464f-9490-fee06985fbeb"],
+	"ddl": [
+		{
+			"name": "account",
+			"entityType": "tables"
+		},
+		{
+			"name": "app_metadata",
+			"entityType": "tables"
+		},
+		{
+			"name": "backup_schedule_mirrors_table",
+			"entityType": "tables"
+		},
+		{
+			"name": "backup_schedule_notifications_table",
+			"entityType": "tables"
+		},
+		{
+			"name": "backup_schedules_table",
+			"entityType": "tables"
+		},
+		{
+			"name": "invitation",
+			"entityType": "tables"
+		},
+		{
+			"name": "member",
+			"entityType": "tables"
+		},
+		{
+			"name": "notification_destinations_table",
+			"entityType": "tables"
+		},
+		{
+			"name": "organization",
+			"entityType": "tables"
+		},
+		{
+			"name": "repositories_table",
+			"entityType": "tables"
+		},
+		{
+			"name": "sessions_table",
+			"entityType": "tables"
+		},
+		{
+			"name": "two_factor",
+			"entityType": "tables"
+		},
+		{
+			"name": "users_table",
+			"entityType": "tables"
+		},
+		{
+			"name": "verification",
+			"entityType": "tables"
+		},
+		{
+			"name": "volumes_table",
+			"entityType": "tables"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "id",
+			"entityType": "columns",
+			"table": "account"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "account_id",
+			"entityType": "columns",
+			"table": "account"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "provider_id",
+			"entityType": "columns",
+			"table": "account"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "user_id",
+			"entityType": "columns",
+			"table": "account"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "access_token",
+			"entityType": "columns",
+			"table": "account"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "refresh_token",
+			"entityType": "columns",
+			"table": "account"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "id_token",
+			"entityType": "columns",
+			"table": "account"
+		},
+		{
+			"type": "integer",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "access_token_expires_at",
+			"entityType": "columns",
+			"table": "account"
+		},
+		{
+			"type": "integer",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "refresh_token_expires_at",
+			"entityType": "columns",
+			"table": "account"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "scope",
+			"entityType": "columns",
+			"table": "account"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "password",
+			"entityType": "columns",
+			"table": "account"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch() * 1000)",
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "account"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch() * 1000)",
+			"generated": null,
+			"name": "updated_at",
+			"entityType": "columns",
+			"table": "account"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "key",
+			"entityType": "columns",
+			"table": "app_metadata"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "value",
+			"entityType": "columns",
+			"table": "app_metadata"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch() * 1000)",
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "app_metadata"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch() * 1000)",
+			"generated": null,
+			"name": "updated_at",
+			"entityType": "columns",
+			"table": "app_metadata"
+		},
+		{
+			"type": "integer",
+			"notNull": false,
+			"autoincrement": true,
+			"default": null,
+			"generated": null,
+			"name": "id",
+			"entityType": "columns",
+			"table": "backup_schedule_mirrors_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "schedule_id",
+			"entityType": "columns",
+			"table": "backup_schedule_mirrors_table"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "repository_id",
+			"entityType": "columns",
+			"table": "backup_schedule_mirrors_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "true",
+			"generated": null,
+			"name": "enabled",
+			"entityType": "columns",
+			"table": "backup_schedule_mirrors_table"
+		},
+		{
+			"type": "integer",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "last_copy_at",
+			"entityType": "columns",
+			"table": "backup_schedule_mirrors_table"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "last_copy_status",
+			"entityType": "columns",
+			"table": "backup_schedule_mirrors_table"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "last_copy_error",
+			"entityType": "columns",
+			"table": "backup_schedule_mirrors_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch() * 1000)",
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "backup_schedule_mirrors_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "schedule_id",
+			"entityType": "columns",
+			"table": "backup_schedule_notifications_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "destination_id",
+			"entityType": "columns",
+			"table": "backup_schedule_notifications_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "false",
+			"generated": null,
+			"name": "notify_on_start",
+			"entityType": "columns",
+			"table": "backup_schedule_notifications_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "false",
+			"generated": null,
+			"name": "notify_on_success",
+			"entityType": "columns",
+			"table": "backup_schedule_notifications_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "true",
+			"generated": null,
+			"name": "notify_on_warning",
+			"entityType": "columns",
+			"table": "backup_schedule_notifications_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "true",
+			"generated": null,
+			"name": "notify_on_failure",
+			"entityType": "columns",
+			"table": "backup_schedule_notifications_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch() * 1000)",
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "backup_schedule_notifications_table"
+		},
+		{
+			"type": "integer",
+			"notNull": false,
+			"autoincrement": true,
+			"default": null,
+			"generated": null,
+			"name": "id",
+			"entityType": "columns",
+			"table": "backup_schedules_table"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "short_id",
+			"entityType": "columns",
+			"table": "backup_schedules_table"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "name",
+			"entityType": "columns",
+			"table": "backup_schedules_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "volume_id",
+			"entityType": "columns",
+			"table": "backup_schedules_table"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "repository_id",
+			"entityType": "columns",
+			"table": "backup_schedules_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "true",
+			"generated": null,
+			"name": "enabled",
+			"entityType": "columns",
+			"table": "backup_schedules_table"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "cron_expression",
+			"entityType": "columns",
+			"table": "backup_schedules_table"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "retention_policy",
+			"entityType": "columns",
+			"table": "backup_schedules_table"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": "'[]'",
+			"generated": null,
+			"name": "exclude_patterns",
+			"entityType": "columns",
+			"table": "backup_schedules_table"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": "'[]'",
+			"generated": null,
+			"name": "exclude_if_present",
+			"entityType": "columns",
+			"table": "backup_schedules_table"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": "'[]'",
+			"generated": null,
+			"name": "include_patterns",
+			"entityType": "columns",
+			"table": "backup_schedules_table"
+		},
+		{
+			"type": "integer",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "last_backup_at",
+			"entityType": "columns",
+			"table": "backup_schedules_table"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "last_backup_status",
+			"entityType": "columns",
+			"table": "backup_schedules_table"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "last_backup_error",
+			"entityType": "columns",
+			"table": "backup_schedules_table"
+		},
+		{
+			"type": "integer",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "next_backup_at",
+			"entityType": "columns",
+			"table": "backup_schedules_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "false",
+			"generated": null,
+			"name": "one_file_system",
+			"entityType": "columns",
+			"table": "backup_schedules_table"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": "'[]'",
+			"generated": null,
+			"name": "custom_restic_params",
+			"entityType": "columns",
+			"table": "backup_schedules_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "0",
+			"generated": null,
+			"name": "sort_order",
+			"entityType": "columns",
+			"table": "backup_schedules_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch() * 1000)",
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "backup_schedules_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch() * 1000)",
+			"generated": null,
+			"name": "updated_at",
+			"entityType": "columns",
+			"table": "backup_schedules_table"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "organization_id",
+			"entityType": "columns",
+			"table": "backup_schedules_table"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "id",
+			"entityType": "columns",
+			"table": "invitation"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "organization_id",
+			"entityType": "columns",
+			"table": "invitation"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "email",
+			"entityType": "columns",
+			"table": "invitation"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "role",
+			"entityType": "columns",
+			"table": "invitation"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "'pending'",
+			"generated": null,
+			"name": "status",
+			"entityType": "columns",
+			"table": "invitation"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "expires_at",
+			"entityType": "columns",
+			"table": "invitation"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "invitation"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "inviter_id",
+			"entityType": "columns",
+			"table": "invitation"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "id",
+			"entityType": "columns",
+			"table": "member"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "organization_id",
+			"entityType": "columns",
+			"table": "member"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "user_id",
+			"entityType": "columns",
+			"table": "member"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "'member'",
+			"generated": null,
+			"name": "role",
+			"entityType": "columns",
+			"table": "member"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "member"
+		},
+		{
+			"type": "integer",
+			"notNull": false,
+			"autoincrement": true,
+			"default": null,
+			"generated": null,
+			"name": "id",
+			"entityType": "columns",
+			"table": "notification_destinations_table"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "name",
+			"entityType": "columns",
+			"table": "notification_destinations_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "true",
+			"generated": null,
+			"name": "enabled",
+			"entityType": "columns",
+			"table": "notification_destinations_table"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "type",
+			"entityType": "columns",
+			"table": "notification_destinations_table"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "config",
+			"entityType": "columns",
+			"table": "notification_destinations_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch() * 1000)",
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "notification_destinations_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch() * 1000)",
+			"generated": null,
+			"name": "updated_at",
+			"entityType": "columns",
+			"table": "notification_destinations_table"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "organization_id",
+			"entityType": "columns",
+			"table": "notification_destinations_table"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "id",
+			"entityType": "columns",
+			"table": "organization"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "name",
+			"entityType": "columns",
+			"table": "organization"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "slug",
+			"entityType": "columns",
+			"table": "organization"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "logo",
+			"entityType": "columns",
+			"table": "organization"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "organization"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "metadata",
+			"entityType": "columns",
+			"table": "organization"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "id",
+			"entityType": "columns",
+			"table": "repositories_table"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "short_id",
+			"entityType": "columns",
+			"table": "repositories_table"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "name",
+			"entityType": "columns",
+			"table": "repositories_table"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "type",
+			"entityType": "columns",
+			"table": "repositories_table"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "config",
+			"entityType": "columns",
+			"table": "repositories_table"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": "'auto'",
+			"generated": null,
+			"name": "compression_mode",
+			"entityType": "columns",
+			"table": "repositories_table"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": "'unknown'",
+			"generated": null,
+			"name": "status",
+			"entityType": "columns",
+			"table": "repositories_table"
+		},
+		{
+			"type": "integer",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "last_checked",
+			"entityType": "columns",
+			"table": "repositories_table"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "last_error",
+			"entityType": "columns",
+			"table": "repositories_table"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "doctor_result",
+			"entityType": "columns",
+			"table": "repositories_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "false",
+			"generated": null,
+			"name": "upload_limit_enabled",
+			"entityType": "columns",
+			"table": "repositories_table"
+		},
+		{
+			"type": "real",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "1",
+			"generated": null,
+			"name": "upload_limit_value",
+			"entityType": "columns",
+			"table": "repositories_table"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "'Mbps'",
+			"generated": null,
+			"name": "upload_limit_unit",
+			"entityType": "columns",
+			"table": "repositories_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "false",
+			"generated": null,
+			"name": "download_limit_enabled",
+			"entityType": "columns",
+			"table": "repositories_table"
+		},
+		{
+			"type": "real",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "1",
+			"generated": null,
+			"name": "download_limit_value",
+			"entityType": "columns",
+			"table": "repositories_table"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "'Mbps'",
+			"generated": null,
+			"name": "download_limit_unit",
+			"entityType": "columns",
+			"table": "repositories_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch() * 1000)",
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "repositories_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch() * 1000)",
+			"generated": null,
+			"name": "updated_at",
+			"entityType": "columns",
+			"table": "repositories_table"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "organization_id",
+			"entityType": "columns",
+			"table": "repositories_table"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "id",
+			"entityType": "columns",
+			"table": "sessions_table"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "user_id",
+			"entityType": "columns",
+			"table": "sessions_table"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "token",
+			"entityType": "columns",
+			"table": "sessions_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "expires_at",
+			"entityType": "columns",
+			"table": "sessions_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch() * 1000)",
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "sessions_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch() * 1000)",
+			"generated": null,
+			"name": "updated_at",
+			"entityType": "columns",
+			"table": "sessions_table"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "ip_address",
+			"entityType": "columns",
+			"table": "sessions_table"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "user_agent",
+			"entityType": "columns",
+			"table": "sessions_table"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "impersonated_by",
+			"entityType": "columns",
+			"table": "sessions_table"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "active_organization_id",
+			"entityType": "columns",
+			"table": "sessions_table"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "id",
+			"entityType": "columns",
+			"table": "two_factor"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "secret",
+			"entityType": "columns",
+			"table": "two_factor"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "backup_codes",
+			"entityType": "columns",
+			"table": "two_factor"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "user_id",
+			"entityType": "columns",
+			"table": "two_factor"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "id",
+			"entityType": "columns",
+			"table": "users_table"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "username",
+			"entityType": "columns",
+			"table": "users_table"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "password_hash",
+			"entityType": "columns",
+			"table": "users_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "false",
+			"generated": null,
+			"name": "has_downloaded_restic_password",
+			"entityType": "columns",
+			"table": "users_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch() * 1000)",
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "users_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch() * 1000)",
+			"generated": null,
+			"name": "updated_at",
+			"entityType": "columns",
+			"table": "users_table"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "name",
+			"entityType": "columns",
+			"table": "users_table"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "email",
+			"entityType": "columns",
+			"table": "users_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "false",
+			"generated": null,
+			"name": "email_verified",
+			"entityType": "columns",
+			"table": "users_table"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "image",
+			"entityType": "columns",
+			"table": "users_table"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "display_username",
+			"entityType": "columns",
+			"table": "users_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "false",
+			"generated": null,
+			"name": "two_factor_enabled",
+			"entityType": "columns",
+			"table": "users_table"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "'user'",
+			"generated": null,
+			"name": "role",
+			"entityType": "columns",
+			"table": "users_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "false",
+			"generated": null,
+			"name": "banned",
+			"entityType": "columns",
+			"table": "users_table"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "ban_reason",
+			"entityType": "columns",
+			"table": "users_table"
+		},
+		{
+			"type": "integer",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "ban_expires",
+			"entityType": "columns",
+			"table": "users_table"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "id",
+			"entityType": "columns",
+			"table": "verification"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "identifier",
+			"entityType": "columns",
+			"table": "verification"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "value",
+			"entityType": "columns",
+			"table": "verification"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "expires_at",
+			"entityType": "columns",
+			"table": "verification"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch() * 1000)",
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "verification"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch() * 1000)",
+			"generated": null,
+			"name": "updated_at",
+			"entityType": "columns",
+			"table": "verification"
+		},
+		{
+			"type": "integer",
+			"notNull": false,
+			"autoincrement": true,
+			"default": null,
+			"generated": null,
+			"name": "id",
+			"entityType": "columns",
+			"table": "volumes_table"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "short_id",
+			"entityType": "columns",
+			"table": "volumes_table"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "name",
+			"entityType": "columns",
+			"table": "volumes_table"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "type",
+			"entityType": "columns",
+			"table": "volumes_table"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "'unmounted'",
+			"generated": null,
+			"name": "status",
+			"entityType": "columns",
+			"table": "volumes_table"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "last_error",
+			"entityType": "columns",
+			"table": "volumes_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch() * 1000)",
+			"generated": null,
+			"name": "last_health_check",
+			"entityType": "columns",
+			"table": "volumes_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch() * 1000)",
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "volumes_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch() * 1000)",
+			"generated": null,
+			"name": "updated_at",
+			"entityType": "columns",
+			"table": "volumes_table"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "config",
+			"entityType": "columns",
+			"table": "volumes_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "true",
+			"generated": null,
+			"name": "auto_remount",
+			"entityType": "columns",
+			"table": "volumes_table"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "organization_id",
+			"entityType": "columns",
+			"table": "volumes_table"
+		},
+		{
+			"columns": ["user_id"],
+			"tableTo": "users_table",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "CASCADE",
+			"nameExplicit": false,
+			"name": "account_user_id_users_table_id_fk",
+			"entityType": "fks",
+			"table": "account"
+		},
+		{
+			"columns": ["schedule_id"],
+			"tableTo": "backup_schedules_table",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "CASCADE",
+			"nameExplicit": false,
+			"name": "backup_schedule_mirrors_table_schedule_id_backup_schedules_table_id_fk",
+			"entityType": "fks",
+			"table": "backup_schedule_mirrors_table"
+		},
+		{
+			"columns": ["repository_id"],
+			"tableTo": "repositories_table",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "CASCADE",
+			"nameExplicit": false,
+			"name": "backup_schedule_mirrors_table_repository_id_repositories_table_id_fk",
+			"entityType": "fks",
+			"table": "backup_schedule_mirrors_table"
+		},
+		{
+			"columns": ["schedule_id"],
+			"tableTo": "backup_schedules_table",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "CASCADE",
+			"nameExplicit": false,
+			"name": "backup_schedule_notifications_table_schedule_id_backup_schedules_table_id_fk",
+			"entityType": "fks",
+			"table": "backup_schedule_notifications_table"
+		},
+		{
+			"columns": ["destination_id"],
+			"tableTo": "notification_destinations_table",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "CASCADE",
+			"nameExplicit": false,
+			"name": "backup_schedule_notifications_table_destination_id_notification_destinations_table_id_fk",
+			"entityType": "fks",
+			"table": "backup_schedule_notifications_table"
+		},
+		{
+			"columns": ["volume_id"],
+			"tableTo": "volumes_table",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "CASCADE",
+			"nameExplicit": false,
+			"name": "backup_schedules_table_volume_id_volumes_table_id_fk",
+			"entityType": "fks",
+			"table": "backup_schedules_table"
+		},
+		{
+			"columns": ["repository_id"],
+			"tableTo": "repositories_table",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "CASCADE",
+			"nameExplicit": false,
+			"name": "backup_schedules_table_repository_id_repositories_table_id_fk",
+			"entityType": "fks",
+			"table": "backup_schedules_table"
+		},
+		{
+			"columns": ["organization_id"],
+			"tableTo": "organization",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "CASCADE",
+			"nameExplicit": false,
+			"name": "backup_schedules_table_organization_id_organization_id_fk",
+			"entityType": "fks",
+			"table": "backup_schedules_table"
+		},
+		{
+			"columns": ["organization_id"],
+			"tableTo": "organization",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "CASCADE",
+			"nameExplicit": false,
+			"name": "invitation_organization_id_organization_id_fk",
+			"entityType": "fks",
+			"table": "invitation"
+		},
+		{
+			"columns": ["inviter_id"],
+			"tableTo": "users_table",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "CASCADE",
+			"nameExplicit": false,
+			"name": "invitation_inviter_id_users_table_id_fk",
+			"entityType": "fks",
+			"table": "invitation"
+		},
+		{
+			"columns": ["organization_id"],
+			"tableTo": "organization",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "CASCADE",
+			"nameExplicit": false,
+			"name": "member_organization_id_organization_id_fk",
+			"entityType": "fks",
+			"table": "member"
+		},
+		{
+			"columns": ["user_id"],
+			"tableTo": "users_table",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "CASCADE",
+			"nameExplicit": false,
+			"name": "member_user_id_users_table_id_fk",
+			"entityType": "fks",
+			"table": "member"
+		},
+		{
+			"columns": ["organization_id"],
+			"tableTo": "organization",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "CASCADE",
+			"nameExplicit": false,
+			"name": "notification_destinations_table_organization_id_organization_id_fk",
+			"entityType": "fks",
+			"table": "notification_destinations_table"
+		},
+		{
+			"columns": ["organization_id"],
+			"tableTo": "organization",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "CASCADE",
+			"nameExplicit": false,
+			"name": "repositories_table_organization_id_organization_id_fk",
+			"entityType": "fks",
+			"table": "repositories_table"
+		},
+		{
+			"columns": ["user_id"],
+			"tableTo": "users_table",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "CASCADE",
+			"nameExplicit": false,
+			"name": "sessions_table_user_id_users_table_id_fk",
+			"entityType": "fks",
+			"table": "sessions_table"
+		},
+		{
+			"columns": ["user_id"],
+			"tableTo": "users_table",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "CASCADE",
+			"nameExplicit": false,
+			"name": "two_factor_user_id_users_table_id_fk",
+			"entityType": "fks",
+			"table": "two_factor"
+		},
+		{
+			"columns": ["organization_id"],
+			"tableTo": "organization",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "CASCADE",
+			"nameExplicit": false,
+			"name": "volumes_table_organization_id_organization_id_fk",
+			"entityType": "fks",
+			"table": "volumes_table"
+		},
+		{
+			"columns": ["schedule_id", "destination_id"],
+			"nameExplicit": false,
+			"name": "backup_schedule_notifications_table_schedule_id_destination_id_pk",
+			"entityType": "pks",
+			"table": "backup_schedule_notifications_table"
+		},
+		{
+			"columns": ["id"],
+			"nameExplicit": false,
+			"name": "account_pk",
+			"table": "account",
+			"entityType": "pks"
+		},
+		{
+			"columns": ["key"],
+			"nameExplicit": false,
+			"name": "app_metadata_pk",
+			"table": "app_metadata",
+			"entityType": "pks"
+		},
+		{
+			"columns": ["id"],
+			"nameExplicit": false,
+			"name": "backup_schedule_mirrors_table_pk",
+			"table": "backup_schedule_mirrors_table",
+			"entityType": "pks"
+		},
+		{
+			"columns": ["id"],
+			"nameExplicit": false,
+			"name": "backup_schedules_table_pk",
+			"table": "backup_schedules_table",
+			"entityType": "pks"
+		},
+		{
+			"columns": ["id"],
+			"nameExplicit": false,
+			"name": "invitation_pk",
+			"table": "invitation",
+			"entityType": "pks"
+		},
+		{
+			"columns": ["id"],
+			"nameExplicit": false,
+			"name": "member_pk",
+			"table": "member",
+			"entityType": "pks"
+		},
+		{
+			"columns": ["id"],
+			"nameExplicit": false,
+			"name": "notification_destinations_table_pk",
+			"table": "notification_destinations_table",
+			"entityType": "pks"
+		},
+		{
+			"columns": ["id"],
+			"nameExplicit": false,
+			"name": "organization_pk",
+			"table": "organization",
+			"entityType": "pks"
+		},
+		{
+			"columns": ["id"],
+			"nameExplicit": false,
+			"name": "repositories_table_pk",
+			"table": "repositories_table",
+			"entityType": "pks"
+		},
+		{
+			"columns": ["id"],
+			"nameExplicit": false,
+			"name": "sessions_table_pk",
+			"table": "sessions_table",
+			"entityType": "pks"
+		},
+		{
+			"columns": ["id"],
+			"nameExplicit": false,
+			"name": "two_factor_pk",
+			"table": "two_factor",
+			"entityType": "pks"
+		},
+		{
+			"columns": ["id"],
+			"nameExplicit": false,
+			"name": "users_table_pk",
+			"table": "users_table",
+			"entityType": "pks"
+		},
+		{
+			"columns": ["id"],
+			"nameExplicit": false,
+			"name": "verification_pk",
+			"table": "verification",
+			"entityType": "pks"
+		},
+		{
+			"columns": ["id"],
+			"nameExplicit": false,
+			"name": "volumes_table_pk",
+			"table": "volumes_table",
+			"entityType": "pks"
+		},
+		{
+			"columns": [
+				{
+					"value": "user_id",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": null,
+			"origin": "manual",
+			"name": "account_userId_idx",
+			"entityType": "indexes",
+			"table": "account"
+		},
+		{
+			"columns": [
+				{
+					"value": "organization_id",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": null,
+			"origin": "manual",
+			"name": "invitation_organizationId_idx",
+			"entityType": "indexes",
+			"table": "invitation"
+		},
+		{
+			"columns": [
+				{
+					"value": "email",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": null,
+			"origin": "manual",
+			"name": "invitation_email_idx",
+			"entityType": "indexes",
+			"table": "invitation"
+		},
+		{
+			"columns": [
+				{
+					"value": "organization_id",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": null,
+			"origin": "manual",
+			"name": "member_organizationId_idx",
+			"entityType": "indexes",
+			"table": "member"
+		},
+		{
+			"columns": [
+				{
+					"value": "user_id",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": null,
+			"origin": "manual",
+			"name": "member_userId_idx",
+			"entityType": "indexes",
+			"table": "member"
+		},
+		{
+			"columns": [
+				{
+					"value": "organization_id",
+					"isExpression": false
+				},
+				{
+					"value": "user_id",
+					"isExpression": false
+				}
+			],
+			"isUnique": true,
+			"where": null,
+			"origin": "manual",
+			"name": "member_org_user_uidx",
+			"entityType": "indexes",
+			"table": "member"
+		},
+		{
+			"columns": [
+				{
+					"value": "slug",
+					"isExpression": false
+				}
+			],
+			"isUnique": true,
+			"where": null,
+			"origin": "manual",
+			"name": "organization_slug_uidx",
+			"entityType": "indexes",
+			"table": "organization"
+		},
+		{
+			"columns": [
+				{
+					"value": "user_id",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": null,
+			"origin": "manual",
+			"name": "sessionsTable_userId_idx",
+			"entityType": "indexes",
+			"table": "sessions_table"
+		},
+		{
+			"columns": [
+				{
+					"value": "secret",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": null,
+			"origin": "manual",
+			"name": "twoFactor_secret_idx",
+			"entityType": "indexes",
+			"table": "two_factor"
+		},
+		{
+			"columns": [
+				{
+					"value": "user_id",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": null,
+			"origin": "manual",
+			"name": "twoFactor_userId_idx",
+			"entityType": "indexes",
+			"table": "two_factor"
+		},
+		{
+			"columns": [
+				{
+					"value": "identifier",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": null,
+			"origin": "manual",
+			"name": "verification_identifier_idx",
+			"entityType": "indexes",
+			"table": "verification"
+		},
+		{
+			"columns": ["schedule_id", "repository_id"],
+			"nameExplicit": false,
+			"name": "backup_schedule_mirrors_table_schedule_id_repository_id_unique",
+			"entityType": "uniques",
+			"table": "backup_schedule_mirrors_table"
+		},
+		{
+			"columns": ["name", "organization_id"],
+			"nameExplicit": false,
+			"name": "volumes_table_name_organization_id_unique",
+			"entityType": "uniques",
+			"table": "volumes_table"
+		},
+		{
+			"columns": ["short_id"],
+			"nameExplicit": false,
+			"name": "backup_schedules_table_short_id_unique",
+			"entityType": "uniques",
+			"table": "backup_schedules_table"
+		},
+		{
+			"columns": ["short_id"],
+			"nameExplicit": false,
+			"name": "repositories_table_short_id_unique",
+			"entityType": "uniques",
+			"table": "repositories_table"
+		},
+		{
+			"columns": ["token"],
+			"nameExplicit": false,
+			"name": "sessions_table_token_unique",
+			"entityType": "uniques",
+			"table": "sessions_table"
+		},
+		{
+			"columns": ["username"],
+			"nameExplicit": false,
+			"name": "users_table_username_unique",
+			"entityType": "uniques",
+			"table": "users_table"
+		},
+		{
+			"columns": ["email"],
+			"nameExplicit": false,
+			"name": "users_table_email_unique",
+			"entityType": "uniques",
+			"table": "users_table"
+		},
+		{
+			"columns": ["short_id"],
+			"nameExplicit": false,
+			"name": "volumes_table_short_id_unique",
+			"entityType": "uniques",
+			"table": "volumes_table"
+		}
+	],
+	"renames": []
+}

--- a/app/server/db/schema.ts
+++ b/app/server/db/schema.ts
@@ -271,6 +271,7 @@ export const backupSchedulesTable = sqliteTable("backup_schedules_table", {
 	lastBackupError: text("last_backup_error"),
 	nextBackupAt: int("next_backup_at", { mode: "number" }),
 	oneFileSystem: int("one_file_system", { mode: "boolean" }).notNull().default(false),
+	customResticParams: text("custom_restic_params", { mode: "json" }).$type<string[]>().default([]),
 	sortOrder: int("sort_order", { mode: "number" }).notNull().default(0),
 	createdAt: int("created_at", { mode: "number" })
 		.notNull()

--- a/app/server/modules/backups/backup.helpers.ts
+++ b/app/server/modules/backups/backup.helpers.ts
@@ -38,4 +38,5 @@ export const createBackupOptions = (schedule: BackupSchedule, volumePath: string
 	exclude: schedule.excludePatterns ? schedule.excludePatterns.map((p) => processPattern(p, volumePath)) : undefined,
 	excludeIfPresent: schedule.excludeIfPresent ?? undefined,
 	include: schedule.includePatterns ? schedule.includePatterns.map((p) => processPattern(p, volumePath)) : undefined,
+	customResticParams: schedule.customResticParams ?? undefined,
 });

--- a/app/server/modules/backups/backups.dto.ts
+++ b/app/server/modules/backups/backups.dto.ts
@@ -29,6 +29,7 @@ const backupScheduleSchema = type({
 	excludeIfPresent: "string[] | null",
 	includePatterns: "string[] | null",
 	oneFileSystem: "boolean",
+	customResticParams: "string[] | null",
 	lastBackupAt: "number | null",
 	lastBackupStatus: "'success' | 'error' | 'in_progress' | 'warning' | null",
 	lastBackupError: "string | null",
@@ -136,6 +137,7 @@ export const createBackupScheduleBody = type({
 	includePatterns: "string[]?",
 	oneFileSystem: "boolean?",
 	tags: "string[]?",
+	customResticParams: "string[]?",
 });
 
 export type CreateBackupScheduleBody = typeof createBackupScheduleBody.infer;
@@ -174,6 +176,7 @@ export const updateBackupScheduleBody = type({
 	includePatterns: "string[]?",
 	oneFileSystem: "boolean?",
 	tags: "string[]?",
+	customResticParams: "string[]?",
 });
 
 export type UpdateBackupScheduleBody = typeof updateBackupScheduleBody.infer;

--- a/app/server/modules/backups/backups.service.ts
+++ b/app/server/modules/backups/backups.service.ts
@@ -134,6 +134,7 @@ const createSchedule = async (data: CreateBackupScheduleBody) => {
 			excludeIfPresent: data.excludeIfPresent ?? [],
 			includePatterns: data.includePatterns ?? [],
 			oneFileSystem: data.oneFileSystem,
+			customResticParams: data.customResticParams ?? [],
 			nextBackupAt: nextBackupAt,
 			shortId: generateShortId(),
 			organizationId,

--- a/app/server/utils/restic/commands/backup.ts
+++ b/app/server/utils/restic/commands/backup.ts
@@ -32,6 +32,7 @@ export const backup = async (
 		compressionMode?: CompressionMode;
 		signal?: AbortSignal;
 		onProgress?: (progress: ResticBackupProgressDto) => void;
+		customResticParams?: string[];
 	},
 ) => {
 	const repoUrl = buildRepoUrl(config);
@@ -82,6 +83,13 @@ export const backup = async (
 	if (options.excludeIfPresent && options.excludeIfPresent.length > 0) {
 		for (const filename of options.excludeIfPresent) {
 			args.push("--exclude-if-present", filename);
+		}
+	}
+
+	if (options.customResticParams && options.customResticParams.length > 0) {
+		for (const param of options.customResticParams) {
+			const tokens = param.trim().split(/\s+/).filter(Boolean);
+			args.push(...tokens);
 		}
 	}
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -38,5 +38,9 @@ export default defineConfig({
 	server: {
 		host: "0.0.0.0",
 		port: 3000,
+		watch: {
+			usePolling: true,
+			ignored: ["**/data/**", "**/*.db", "**/*.db-journal", "**/*.db-wal", "**/*.db-shm"],
+		},
 	},
 });


### PR DESCRIPTION
Allows users to pass arbitrary restic flags via a new advanced section in the create/edit schedule form. Includes DB migration, schema update, DTO, service, and restic command changes.

I started with the original need to be able to pass in the --ignore-inode --ignore-ctime arguments, implemented it in this way to be more general.