### PR TITLE
fix: lazy load repository stats on-demand to reduce CPU/Mem

### DIFF
--- a/app/routes/(dashboard)/repositories/$repositoryId/index.tsx
+++ b/app/routes/(dashboard)/repositories/$repositoryId/index.tsx
@@ -2,7 +2,6 @@ import { createFileRoute } from "@tanstack/react-router";
 import { type } from "arktype";
 import {
 	getRepositoryOptions,
-	getRepositoryStatsOptions,
 	listBackupSchedulesOptions,
 	listSnapshotsOptions,
 } from "~/client/api-client/@tanstack/react-query.gen";
@@ -14,20 +13,17 @@ export const Route = createFileRoute("/(dashboard)/repositories/$repositoryId/")
 	errorComponent: (e) => <div>{e.error.message}</div>,
 	loader: async ({ params, context }) => {
 		const snapshotOptions = listSnapshotsOptions({ path: { shortId: params.repositoryId } });
-		const statsOptions = getRepositoryStatsOptions({ path: { shortId: params.repositoryId } });
 
-		const [res, schedules] = await Promise.all([
+		const [res, schedules, snapshots] = await Promise.all([
 			context.queryClient.ensureQueryData(getRepositoryOptions({ path: { shortId: params.repositoryId } })),
 			context.queryClient.ensureQueryData(listBackupSchedulesOptions()),
 			prefetchOrSkip(context.queryClient, snapshotOptions),
-			prefetchOrSkip(context.queryClient, statsOptions),
 		]);
 
 		return {
 			...res,
 			snapshots: context.queryClient.getQueryData(snapshotOptions.queryKey),
 			backupSchedules: schedules,
-			stats: context.queryClient.getQueryData(statsOptions.queryKey),
 		};
 	},
 	validateSearch: type({ tab: "string?" }),
@@ -50,14 +46,13 @@ export const Route = createFileRoute("/(dashboard)/repositories/$repositoryId/")
 
 function RouteComponent() {
 	const { repositoryId } = Route.useParams();
-	const { snapshots, backupSchedules, stats } = Route.useLoaderData();
+	const { snapshots, backupSchedules } = Route.useLoaderData();
 
 	return (
 		<RepositoryDetailsPage
 			repositoryId={repositoryId}
 			initialSnapshots={snapshots}
 			initialBackupSchedules={backupSchedules}
-			initialStats={stats}
 		/>
 	);
 }


### PR DESCRIPTION
Fixes #614

The repositories page was eagerly fetching restic stats on every page load, which causes high CPU/Memory usage for large repositories (especially multi-TB Backblaze repos). This fix removes the eager loading from the route loader, so stats are now fetched on-demand by the frontend component instead.

This resolves the issue where:
- Loading the repository page would trigger restic stats immediately
- Refreshing the page would trigger additional calls to restic stats (even if the first one was not complete)
- Resource consumption would ramp up significantly

The backend caching is still in place, so repeated fetches will use the cache.

---
*Contributed by [theluckystrike](https://github.com/theluckystrike) | [Zovo](https://zovo.one) — Chrome Extension Studio*