### PR TITLE
feat(backup): retry backup after failed attempt 

### DIFF
--- a/app/client/api-client/types.gen.ts
+++ b/app/client/api-client/types.gen.ts
@@ -2712,6 +2712,8 @@ export type CreateBackupScheduleData = {
         oneFileSystem?: boolean;
         tags?: Array<string>;
         customResticParams?: Array<string>;
+        maxRetries?: number;
+        retryDelay?: number;
     };
     path?: never;
     query?: never;
@@ -3091,6 +3093,8 @@ export type UpdateBackupScheduleData = {
         oneFileSystem?: boolean;
         tags?: Array<string>;
         customResticParams?: Array<string>;
+        maxRetries?: number;
+        retryDelay?: number;
     };
     path: {
         shortId: string;

--- a/app/client/api-client/types.gen.ts
+++ b/app/client/api-client/types.gen.ts
@@ -2434,6 +2434,8 @@ export type ListBackupSchedulesResponses = {
         includePatterns: Array<string> | null;
         oneFileSystem: boolean;
         customResticParams: Array<string> | null;
+        maxRetries: number;
+        retryDelay: number;
         lastBackupAt: number | null;
         lastBackupStatus: 'success' | 'error' | 'in_progress' | 'warning' | null;
         lastBackupError: string | null;
@@ -2743,6 +2745,8 @@ export type CreateBackupScheduleResponses = {
         includePatterns: Array<string> | null;
         oneFileSystem: boolean;
         customResticParams: Array<string> | null;
+        maxRetries: number;
+        retryDelay: number;
         lastBackupAt: number | null;
         lastBackupStatus: 'success' | 'error' | 'in_progress' | 'warning' | null;
         lastBackupError: string | null;
@@ -2810,6 +2814,8 @@ export type GetBackupScheduleResponses = {
         includePatterns: Array<string> | null;
         oneFileSystem: boolean;
         customResticParams: Array<string> | null;
+        maxRetries: number;
+        retryDelay: number;
         lastBackupAt: number | null;
         lastBackupStatus: 'success' | 'error' | 'in_progress' | 'warning' | null;
         lastBackupError: string | null;
@@ -3120,6 +3126,8 @@ export type UpdateBackupScheduleResponses = {
         includePatterns: Array<string> | null;
         oneFileSystem: boolean;
         customResticParams: Array<string> | null;
+        maxRetries: number;
+        retryDelay: number;
         lastBackupAt: number | null;
         lastBackupStatus: 'success' | 'error' | 'in_progress' | 'warning' | null;
         lastBackupError: string | null;
@@ -3167,6 +3175,8 @@ export type GetBackupScheduleForVolumeResponses = {
         includePatterns: Array<string> | null;
         oneFileSystem: boolean;
         customResticParams: Array<string> | null;
+        maxRetries: number;
+        retryDelay: number;
         lastBackupAt: number | null;
         lastBackupStatus: 'success' | 'error' | 'in_progress' | 'warning' | null;
         lastBackupError: string | null;

--- a/app/client/modules/backups/components/create-schedule-form/advanced-section.tsx
+++ b/app/client/modules/backups/components/create-schedule-form/advanced-section.tsx
@@ -2,6 +2,7 @@ import { FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessa
 import { Textarea } from "~/client/components/ui/textarea";
 import type { UseFormReturn } from "react-hook-form";
 import type { InternalFormValues } from "./types";
+import { Input } from "~/client/components/ui/input";
 
 type AdvancedSectionProps = {
 	form: UseFormReturn<InternalFormValues>;
@@ -9,27 +10,72 @@ type AdvancedSectionProps = {
 
 export const AdvancedSection = ({ form }: AdvancedSectionProps) => {
 	return (
-		<FormField
-			control={form.control}
-			name="customResticParamsText"
-			render={({ field }) => (
-				<FormItem>
-					<FormLabel>Custom restic parameters</FormLabel>
-					<FormControl>
-						<Textarea
-							{...field}
-							placeholder="--exclude-larger-than 500M&#10;--no-scan&#10;--read-concurrency 8"
-							className="font-mono text-sm min-h-24"
-						/>
-					</FormControl>
-					<FormDescription>
-						Advanced: enter one restic flag per line (e.g.{" "}
-						<code className="bg-muted px-1 rounded">--exclude-larger-than 500M</code>). Only the supported flag list is
-						accepted.
-					</FormDescription>
-					<FormMessage />
-				</FormItem>
-			)}
-		/>
+		<>
+			<FormField
+				control={form.control}
+				name="maxRetries"
+				render={({ field }) => (
+					<FormItem>
+						<FormLabel>Maximum retries</FormLabel>
+						<FormControl>
+							<Input
+								{...field}
+								type="number"
+								min={0}
+								max={32}
+								value={field.value ?? ""}
+								onChange={(e) => field.onChange(e.target.value ? Number(e.target.value) : undefined)}
+							/>
+						</FormControl>
+						<FormDescription>Maximum number of retry attempts if a backup fails (default: 0).</FormDescription>
+						<FormMessage />
+					</FormItem>
+				)}
+			/>
+			<FormField
+				control={form.control}
+				name="retryDelay"
+				render={({ field }) => (
+					<FormItem>
+						<FormLabel>Retry delay</FormLabel>
+						<FormControl>
+							<Input
+								{...field}
+								type="number"
+								min={0}
+								max={1440}
+								step={1}
+								value={field.value ?? ""}
+								onChange={(e) => field.onChange(e.target.value ? Number(e.target.value) : undefined)}
+							/>
+						</FormControl>
+						<FormDescription>Delay in minutes before retrying a failed backup (default: 60 minutes).</FormDescription>
+						<FormMessage />
+					</FormItem>
+				)}
+			/>
+			<FormField
+				control={form.control}
+				name="customResticParamsText"
+				render={({ field }) => (
+					<FormItem>
+						<FormLabel>Custom restic parameters</FormLabel>
+						<FormControl>
+							<Textarea
+								{...field}
+								placeholder="--exclude-larger-than 500M&#10;--no-scan&#10;--read-concurrency 8"
+								className="font-mono text-sm min-h-24"
+							/>
+						</FormControl>
+						<FormDescription>
+							Advanced: enter one restic flag per line (e.g.{" "}
+							<code className="bg-muted px-1 rounded">--exclude-larger-than 500M</code>). Only the supported flag list
+							is accepted.
+						</FormDescription>
+						<FormMessage />
+					</FormItem>
+				)}
+			/>
+		</>
 	);
 };

--- a/app/client/modules/backups/components/create-schedule-form/advanced-section.tsx
+++ b/app/client/modules/backups/components/create-schedule-form/advanced-section.tsx
@@ -28,7 +28,7 @@ export const AdvancedSection = ({ form }: AdvancedSectionProps) => {
 								onChange={(e) => field.onChange(e.target.value ? Number(e.target.value) : undefined)}
 							/>
 						</FormControl>
-						<FormDescription>Maximum number of retry attempts if a backup fails (default: 0).</FormDescription>
+						<FormDescription>Maximum number of retry attempts if a backup fails (default: 3).</FormDescription>
 						<FormMessage />
 					</FormItem>
 				)}
@@ -43,7 +43,7 @@ export const AdvancedSection = ({ form }: AdvancedSectionProps) => {
 							<Input
 								{...field}
 								type="number"
-								min={0}
+								min={1}
 								max={1440}
 								step={1}
 								placeholder="e.g., 60"

--- a/app/client/modules/backups/components/create-schedule-form/advanced-section.tsx
+++ b/app/client/modules/backups/components/create-schedule-form/advanced-section.tsx
@@ -24,6 +24,7 @@ export const AdvancedSection = ({ form }: AdvancedSectionProps) => {
 								min={0}
 								max={32}
 								value={field.value ?? ""}
+								placeholder="e.g., 3"
 								onChange={(e) => field.onChange(e.target.value ? Number(e.target.value) : undefined)}
 							/>
 						</FormControl>
@@ -45,6 +46,7 @@ export const AdvancedSection = ({ form }: AdvancedSectionProps) => {
 								min={0}
 								max={1440}
 								step={1}
+								placeholder="e.g., 60"
 								value={field.value ?? ""}
 								onChange={(e) => field.onChange(e.target.value ? Number(e.target.value) : undefined)}
 							/>

--- a/app/client/modules/backups/components/create-schedule-form/index.tsx
+++ b/app/client/modules/backups/components/create-schedule-form/index.tsx
@@ -44,6 +44,8 @@ export const CreateScheduleForm = ({ initialValues, formId, onSubmit, volume }: 
 				customResticParamsText,
 				includePaths,
 				cronExpression,
+				maxRetries,
+				retryDelay,
 				...rest
 			} = data;
 			const excludePatterns = parseMultilineEntries(excludePatternsText);
@@ -59,6 +61,8 @@ export const CreateScheduleForm = ({ initialValues, formId, onSubmit, volume }: 
 				excludePatterns,
 				excludeIfPresent,
 				customResticParams,
+				maxRetries,
+				retryDelay: retryDelay ? retryDelay * 60 * 1000 : 3600000,
 			});
 		},
 		[onSubmit],

--- a/app/client/modules/backups/components/create-schedule-form/index.tsx
+++ b/app/client/modules/backups/components/create-schedule-form/index.tsx
@@ -62,7 +62,7 @@ export const CreateScheduleForm = ({ initialValues, formId, onSubmit, volume }: 
 				excludeIfPresent,
 				customResticParams,
 				maxRetries,
-				retryDelay: retryDelay ? retryDelay * 60 * 1000 : 3600000,
+				retryDelay,
 			});
 		},
 		[onSubmit],

--- a/app/client/modules/backups/components/create-schedule-form/types.ts
+++ b/app/client/modules/backups/components/create-schedule-form/types.ts
@@ -20,6 +20,8 @@ export const internalFormSchema = z.object({
 	keepYearly: z.number().optional(),
 	oneFileSystem: z.boolean().optional(),
 	customResticParamsText: z.string().optional(),
+	maxRetries: z.number().min(0).max(32).optional(),
+	retryDelay: z.number().min(1).max(1440).optional(),
 });
 
 export const weeklyDays = [
@@ -42,4 +44,6 @@ export type BackupScheduleFormValues = Omit<
 	excludeIfPresent?: string[];
 	includePatterns?: string[];
 	customResticParams?: string[];
+	maxRetries?: number;
+	retryDelay?: number;
 };

--- a/app/client/modules/backups/components/create-schedule-form/types.ts
+++ b/app/client/modules/backups/components/create-schedule-form/types.ts
@@ -44,6 +44,4 @@ export type BackupScheduleFormValues = Omit<
 	excludeIfPresent?: string[];
 	includePatterns?: string[];
 	customResticParams?: string[];
-	maxRetries?: number;
-	retryDelay?: number;
 };

--- a/app/client/modules/backups/components/create-schedule-form/utils.ts
+++ b/app/client/modules/backups/components/create-schedule-form/utils.ts
@@ -26,6 +26,8 @@ export const backupScheduleToFormValues = (schedule?: BackupSchedule): InternalF
 		excludeIfPresentText: schedule.excludeIfPresent?.join("\n") || undefined,
 		oneFileSystem: schedule.oneFileSystem ?? false,
 		customResticParamsText: schedule.customResticParams?.join("\n") ?? "",
+		maxRetries: schedule.maxRetries ?? 5,
+		retryDelay: schedule.retryDelay ? schedule.retryDelay / (60 * 60 * 1000) : 1, // Convert ms to hours
 		...cronValues,
 		...schedule.retentionPolicy,
 	};

--- a/app/client/modules/backups/components/create-schedule-form/utils.ts
+++ b/app/client/modules/backups/components/create-schedule-form/utils.ts
@@ -26,8 +26,8 @@ export const backupScheduleToFormValues = (schedule?: BackupSchedule): InternalF
 		excludeIfPresentText: schedule.excludeIfPresent?.join("\n") || undefined,
 		oneFileSystem: schedule.oneFileSystem ?? false,
 		customResticParamsText: schedule.customResticParams?.join("\n") ?? "",
-		maxRetries: schedule.maxRetries ?? 5,
-		retryDelay: schedule.retryDelay ? schedule.retryDelay / (60 * 60 * 1000) : 1, // Convert ms to hours
+		maxRetries: schedule.maxRetries,
+		retryDelay: schedule.retryDelay ? schedule.retryDelay / (60 * 1000) : undefined, // Convert ms to minutes
 		...cronValues,
 		...schedule.retentionPolicy,
 	};

--- a/app/client/modules/backups/routes/create-backup.tsx
+++ b/app/client/modules/backups/routes/create-backup.tsx
@@ -75,6 +75,8 @@ export function CreateBackupPage() {
 				excludeIfPresent: formValues.excludeIfPresent,
 				oneFileSystem: formValues.oneFileSystem,
 				customResticParams: formValues.customResticParams,
+				maxRetries: formValues.maxRetries,
+				retryDelay: formValues.retryDelay,
 			},
 		});
 	};

--- a/app/drizzle/20260407172925_fresh_warlock/migration.sql
+++ b/app/drizzle/20260407172925_fresh_warlock/migration.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `backup_schedules_table` ADD `failure_retry_count` integer DEFAULT 0 NOT NULL;--> statement-breakpoint
+ALTER TABLE `backup_schedules_table` ADD `max_retries` integer DEFAULT 3 NOT NULL;--> statement-breakpoint
+ALTER TABLE `backup_schedules_table` ADD `retry_delay` integer DEFAULT 3600000 NOT NULL;

--- a/app/drizzle/20260407172925_fresh_warlock/snapshot.json
+++ b/app/drizzle/20260407172925_fresh_warlock/snapshot.json
@@ -1,0 +1,2331 @@
+{
+	"version": "7",
+	"dialect": "sqlite",
+	"id": "11dfb429-048c-4f65-abf1-f25ac2ae9d93",
+	"prevIds": ["fbd52162-d4fb-4c62-b79a-17078cb469b3"],
+	"ddl": [
+		{
+			"name": "account",
+			"entityType": "tables"
+		},
+		{
+			"name": "app_metadata",
+			"entityType": "tables"
+		},
+		{
+			"name": "backup_schedule_mirrors_table",
+			"entityType": "tables"
+		},
+		{
+			"name": "backup_schedule_notifications_table",
+			"entityType": "tables"
+		},
+		{
+			"name": "backup_schedules_table",
+			"entityType": "tables"
+		},
+		{
+			"name": "invitation",
+			"entityType": "tables"
+		},
+		{
+			"name": "member",
+			"entityType": "tables"
+		},
+		{
+			"name": "notification_destinations_table",
+			"entityType": "tables"
+		},
+		{
+			"name": "organization",
+			"entityType": "tables"
+		},
+		{
+			"name": "repositories_table",
+			"entityType": "tables"
+		},
+		{
+			"name": "sessions_table",
+			"entityType": "tables"
+		},
+		{
+			"name": "sso_provider",
+			"entityType": "tables"
+		},
+		{
+			"name": "two_factor",
+			"entityType": "tables"
+		},
+		{
+			"name": "users_table",
+			"entityType": "tables"
+		},
+		{
+			"name": "verification",
+			"entityType": "tables"
+		},
+		{
+			"name": "volumes_table",
+			"entityType": "tables"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "id",
+			"entityType": "columns",
+			"table": "account"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "account_id",
+			"entityType": "columns",
+			"table": "account"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "provider_id",
+			"entityType": "columns",
+			"table": "account"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "user_id",
+			"entityType": "columns",
+			"table": "account"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "access_token",
+			"entityType": "columns",
+			"table": "account"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "refresh_token",
+			"entityType": "columns",
+			"table": "account"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "id_token",
+			"entityType": "columns",
+			"table": "account"
+		},
+		{
+			"type": "integer",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "access_token_expires_at",
+			"entityType": "columns",
+			"table": "account"
+		},
+		{
+			"type": "integer",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "refresh_token_expires_at",
+			"entityType": "columns",
+			"table": "account"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "scope",
+			"entityType": "columns",
+			"table": "account"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "password",
+			"entityType": "columns",
+			"table": "account"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch() * 1000)",
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "account"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch() * 1000)",
+			"generated": null,
+			"name": "updated_at",
+			"entityType": "columns",
+			"table": "account"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "key",
+			"entityType": "columns",
+			"table": "app_metadata"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "value",
+			"entityType": "columns",
+			"table": "app_metadata"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch() * 1000)",
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "app_metadata"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch() * 1000)",
+			"generated": null,
+			"name": "updated_at",
+			"entityType": "columns",
+			"table": "app_metadata"
+		},
+		{
+			"type": "integer",
+			"notNull": false,
+			"autoincrement": true,
+			"default": null,
+			"generated": null,
+			"name": "id",
+			"entityType": "columns",
+			"table": "backup_schedule_mirrors_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "schedule_id",
+			"entityType": "columns",
+			"table": "backup_schedule_mirrors_table"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "repository_id",
+			"entityType": "columns",
+			"table": "backup_schedule_mirrors_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "true",
+			"generated": null,
+			"name": "enabled",
+			"entityType": "columns",
+			"table": "backup_schedule_mirrors_table"
+		},
+		{
+			"type": "integer",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "last_copy_at",
+			"entityType": "columns",
+			"table": "backup_schedule_mirrors_table"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "last_copy_status",
+			"entityType": "columns",
+			"table": "backup_schedule_mirrors_table"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "last_copy_error",
+			"entityType": "columns",
+			"table": "backup_schedule_mirrors_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch() * 1000)",
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "backup_schedule_mirrors_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "schedule_id",
+			"entityType": "columns",
+			"table": "backup_schedule_notifications_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "destination_id",
+			"entityType": "columns",
+			"table": "backup_schedule_notifications_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "false",
+			"generated": null,
+			"name": "notify_on_start",
+			"entityType": "columns",
+			"table": "backup_schedule_notifications_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "false",
+			"generated": null,
+			"name": "notify_on_success",
+			"entityType": "columns",
+			"table": "backup_schedule_notifications_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "true",
+			"generated": null,
+			"name": "notify_on_warning",
+			"entityType": "columns",
+			"table": "backup_schedule_notifications_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "true",
+			"generated": null,
+			"name": "notify_on_failure",
+			"entityType": "columns",
+			"table": "backup_schedule_notifications_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch() * 1000)",
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "backup_schedule_notifications_table"
+		},
+		{
+			"type": "integer",
+			"notNull": false,
+			"autoincrement": true,
+			"default": null,
+			"generated": null,
+			"name": "id",
+			"entityType": "columns",
+			"table": "backup_schedules_table"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "short_id",
+			"entityType": "columns",
+			"table": "backup_schedules_table"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "name",
+			"entityType": "columns",
+			"table": "backup_schedules_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "volume_id",
+			"entityType": "columns",
+			"table": "backup_schedules_table"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "repository_id",
+			"entityType": "columns",
+			"table": "backup_schedules_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "true",
+			"generated": null,
+			"name": "enabled",
+			"entityType": "columns",
+			"table": "backup_schedules_table"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "cron_expression",
+			"entityType": "columns",
+			"table": "backup_schedules_table"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "retention_policy",
+			"entityType": "columns",
+			"table": "backup_schedules_table"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": "'[]'",
+			"generated": null,
+			"name": "exclude_patterns",
+			"entityType": "columns",
+			"table": "backup_schedules_table"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": "'[]'",
+			"generated": null,
+			"name": "exclude_if_present",
+			"entityType": "columns",
+			"table": "backup_schedules_table"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": "'[]'",
+			"generated": null,
+			"name": "include_paths",
+			"entityType": "columns",
+			"table": "backup_schedules_table"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": "'[]'",
+			"generated": null,
+			"name": "include_patterns",
+			"entityType": "columns",
+			"table": "backup_schedules_table"
+		},
+		{
+			"type": "integer",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "last_backup_at",
+			"entityType": "columns",
+			"table": "backup_schedules_table"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "last_backup_status",
+			"entityType": "columns",
+			"table": "backup_schedules_table"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "last_backup_error",
+			"entityType": "columns",
+			"table": "backup_schedules_table"
+		},
+		{
+			"type": "integer",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "next_backup_at",
+			"entityType": "columns",
+			"table": "backup_schedules_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "false",
+			"generated": null,
+			"name": "one_file_system",
+			"entityType": "columns",
+			"table": "backup_schedules_table"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": "'[]'",
+			"generated": null,
+			"name": "custom_restic_params",
+			"entityType": "columns",
+			"table": "backup_schedules_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "0",
+			"generated": null,
+			"name": "sort_order",
+			"entityType": "columns",
+			"table": "backup_schedules_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "0",
+			"generated": null,
+			"name": "failure_retry_count",
+			"entityType": "columns",
+			"table": "backup_schedules_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "3",
+			"generated": null,
+			"name": "max_retries",
+			"entityType": "columns",
+			"table": "backup_schedules_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "3600000",
+			"generated": null,
+			"name": "retry_delay",
+			"entityType": "columns",
+			"table": "backup_schedules_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch() * 1000)",
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "backup_schedules_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch() * 1000)",
+			"generated": null,
+			"name": "updated_at",
+			"entityType": "columns",
+			"table": "backup_schedules_table"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "organization_id",
+			"entityType": "columns",
+			"table": "backup_schedules_table"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "id",
+			"entityType": "columns",
+			"table": "invitation"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "organization_id",
+			"entityType": "columns",
+			"table": "invitation"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "email",
+			"entityType": "columns",
+			"table": "invitation"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "role",
+			"entityType": "columns",
+			"table": "invitation"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "'pending'",
+			"generated": null,
+			"name": "status",
+			"entityType": "columns",
+			"table": "invitation"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "expires_at",
+			"entityType": "columns",
+			"table": "invitation"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "invitation"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "inviter_id",
+			"entityType": "columns",
+			"table": "invitation"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "id",
+			"entityType": "columns",
+			"table": "member"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "organization_id",
+			"entityType": "columns",
+			"table": "member"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "user_id",
+			"entityType": "columns",
+			"table": "member"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "'member'",
+			"generated": null,
+			"name": "role",
+			"entityType": "columns",
+			"table": "member"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "member"
+		},
+		{
+			"type": "integer",
+			"notNull": false,
+			"autoincrement": true,
+			"default": null,
+			"generated": null,
+			"name": "id",
+			"entityType": "columns",
+			"table": "notification_destinations_table"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "name",
+			"entityType": "columns",
+			"table": "notification_destinations_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "true",
+			"generated": null,
+			"name": "enabled",
+			"entityType": "columns",
+			"table": "notification_destinations_table"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "type",
+			"entityType": "columns",
+			"table": "notification_destinations_table"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "config",
+			"entityType": "columns",
+			"table": "notification_destinations_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch() * 1000)",
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "notification_destinations_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch() * 1000)",
+			"generated": null,
+			"name": "updated_at",
+			"entityType": "columns",
+			"table": "notification_destinations_table"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "organization_id",
+			"entityType": "columns",
+			"table": "notification_destinations_table"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "id",
+			"entityType": "columns",
+			"table": "organization"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "name",
+			"entityType": "columns",
+			"table": "organization"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "slug",
+			"entityType": "columns",
+			"table": "organization"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "logo",
+			"entityType": "columns",
+			"table": "organization"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "organization"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "metadata",
+			"entityType": "columns",
+			"table": "organization"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "id",
+			"entityType": "columns",
+			"table": "repositories_table"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "short_id",
+			"entityType": "columns",
+			"table": "repositories_table"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "provisioning_id",
+			"entityType": "columns",
+			"table": "repositories_table"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "name",
+			"entityType": "columns",
+			"table": "repositories_table"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "type",
+			"entityType": "columns",
+			"table": "repositories_table"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "config",
+			"entityType": "columns",
+			"table": "repositories_table"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": "'auto'",
+			"generated": null,
+			"name": "compression_mode",
+			"entityType": "columns",
+			"table": "repositories_table"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": "'unknown'",
+			"generated": null,
+			"name": "status",
+			"entityType": "columns",
+			"table": "repositories_table"
+		},
+		{
+			"type": "integer",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "last_checked",
+			"entityType": "columns",
+			"table": "repositories_table"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "last_error",
+			"entityType": "columns",
+			"table": "repositories_table"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "doctor_result",
+			"entityType": "columns",
+			"table": "repositories_table"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "stats",
+			"entityType": "columns",
+			"table": "repositories_table"
+		},
+		{
+			"type": "integer",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "stats_updated_at",
+			"entityType": "columns",
+			"table": "repositories_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "false",
+			"generated": null,
+			"name": "upload_limit_enabled",
+			"entityType": "columns",
+			"table": "repositories_table"
+		},
+		{
+			"type": "real",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "1",
+			"generated": null,
+			"name": "upload_limit_value",
+			"entityType": "columns",
+			"table": "repositories_table"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "'Mbps'",
+			"generated": null,
+			"name": "upload_limit_unit",
+			"entityType": "columns",
+			"table": "repositories_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "false",
+			"generated": null,
+			"name": "download_limit_enabled",
+			"entityType": "columns",
+			"table": "repositories_table"
+		},
+		{
+			"type": "real",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "1",
+			"generated": null,
+			"name": "download_limit_value",
+			"entityType": "columns",
+			"table": "repositories_table"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "'Mbps'",
+			"generated": null,
+			"name": "download_limit_unit",
+			"entityType": "columns",
+			"table": "repositories_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch() * 1000)",
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "repositories_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch() * 1000)",
+			"generated": null,
+			"name": "updated_at",
+			"entityType": "columns",
+			"table": "repositories_table"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "organization_id",
+			"entityType": "columns",
+			"table": "repositories_table"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "id",
+			"entityType": "columns",
+			"table": "sessions_table"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "user_id",
+			"entityType": "columns",
+			"table": "sessions_table"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "token",
+			"entityType": "columns",
+			"table": "sessions_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "expires_at",
+			"entityType": "columns",
+			"table": "sessions_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch() * 1000)",
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "sessions_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch() * 1000)",
+			"generated": null,
+			"name": "updated_at",
+			"entityType": "columns",
+			"table": "sessions_table"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "ip_address",
+			"entityType": "columns",
+			"table": "sessions_table"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "user_agent",
+			"entityType": "columns",
+			"table": "sessions_table"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "impersonated_by",
+			"entityType": "columns",
+			"table": "sessions_table"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "active_organization_id",
+			"entityType": "columns",
+			"table": "sessions_table"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "id",
+			"entityType": "columns",
+			"table": "sso_provider"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "provider_id",
+			"entityType": "columns",
+			"table": "sso_provider"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "organization_id",
+			"entityType": "columns",
+			"table": "sso_provider"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "user_id",
+			"entityType": "columns",
+			"table": "sso_provider"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "issuer",
+			"entityType": "columns",
+			"table": "sso_provider"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "domain",
+			"entityType": "columns",
+			"table": "sso_provider"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "false",
+			"generated": null,
+			"name": "auto_link_matching_emails",
+			"entityType": "columns",
+			"table": "sso_provider"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "oidc_config",
+			"entityType": "columns",
+			"table": "sso_provider"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "saml_config",
+			"entityType": "columns",
+			"table": "sso_provider"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch() * 1000)",
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "sso_provider"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch() * 1000)",
+			"generated": null,
+			"name": "updated_at",
+			"entityType": "columns",
+			"table": "sso_provider"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "id",
+			"entityType": "columns",
+			"table": "two_factor"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "secret",
+			"entityType": "columns",
+			"table": "two_factor"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "backup_codes",
+			"entityType": "columns",
+			"table": "two_factor"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "user_id",
+			"entityType": "columns",
+			"table": "two_factor"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "id",
+			"entityType": "columns",
+			"table": "users_table"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "username",
+			"entityType": "columns",
+			"table": "users_table"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "password_hash",
+			"entityType": "columns",
+			"table": "users_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "false",
+			"generated": null,
+			"name": "has_downloaded_restic_password",
+			"entityType": "columns",
+			"table": "users_table"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "'MM/DD/YYYY'",
+			"generated": null,
+			"name": "date_format",
+			"entityType": "columns",
+			"table": "users_table"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "'12h'",
+			"generated": null,
+			"name": "time_format",
+			"entityType": "columns",
+			"table": "users_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch() * 1000)",
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "users_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch() * 1000)",
+			"generated": null,
+			"name": "updated_at",
+			"entityType": "columns",
+			"table": "users_table"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "name",
+			"entityType": "columns",
+			"table": "users_table"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "email",
+			"entityType": "columns",
+			"table": "users_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "false",
+			"generated": null,
+			"name": "email_verified",
+			"entityType": "columns",
+			"table": "users_table"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "image",
+			"entityType": "columns",
+			"table": "users_table"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "display_username",
+			"entityType": "columns",
+			"table": "users_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "false",
+			"generated": null,
+			"name": "two_factor_enabled",
+			"entityType": "columns",
+			"table": "users_table"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "'user'",
+			"generated": null,
+			"name": "role",
+			"entityType": "columns",
+			"table": "users_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "false",
+			"generated": null,
+			"name": "banned",
+			"entityType": "columns",
+			"table": "users_table"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "ban_reason",
+			"entityType": "columns",
+			"table": "users_table"
+		},
+		{
+			"type": "integer",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "ban_expires",
+			"entityType": "columns",
+			"table": "users_table"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "id",
+			"entityType": "columns",
+			"table": "verification"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "identifier",
+			"entityType": "columns",
+			"table": "verification"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "value",
+			"entityType": "columns",
+			"table": "verification"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "expires_at",
+			"entityType": "columns",
+			"table": "verification"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch() * 1000)",
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "verification"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch() * 1000)",
+			"generated": null,
+			"name": "updated_at",
+			"entityType": "columns",
+			"table": "verification"
+		},
+		{
+			"type": "integer",
+			"notNull": false,
+			"autoincrement": true,
+			"default": null,
+			"generated": null,
+			"name": "id",
+			"entityType": "columns",
+			"table": "volumes_table"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "short_id",
+			"entityType": "columns",
+			"table": "volumes_table"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "provisioning_id",
+			"entityType": "columns",
+			"table": "volumes_table"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "name",
+			"entityType": "columns",
+			"table": "volumes_table"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "type",
+			"entityType": "columns",
+			"table": "volumes_table"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "'unmounted'",
+			"generated": null,
+			"name": "status",
+			"entityType": "columns",
+			"table": "volumes_table"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "last_error",
+			"entityType": "columns",
+			"table": "volumes_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch() * 1000)",
+			"generated": null,
+			"name": "last_health_check",
+			"entityType": "columns",
+			"table": "volumes_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch() * 1000)",
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "volumes_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch() * 1000)",
+			"generated": null,
+			"name": "updated_at",
+			"entityType": "columns",
+			"table": "volumes_table"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "config",
+			"entityType": "columns",
+			"table": "volumes_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "true",
+			"generated": null,
+			"name": "auto_remount",
+			"entityType": "columns",
+			"table": "volumes_table"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "organization_id",
+			"entityType": "columns",
+			"table": "volumes_table"
+		},
+		{
+			"columns": ["user_id"],
+			"tableTo": "users_table",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "CASCADE",
+			"nameExplicit": false,
+			"name": "account_user_id_users_table_id_fk",
+			"entityType": "fks",
+			"table": "account"
+		},
+		{
+			"columns": ["schedule_id"],
+			"tableTo": "backup_schedules_table",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "CASCADE",
+			"nameExplicit": false,
+			"name": "backup_schedule_mirrors_table_schedule_id_backup_schedules_table_id_fk",
+			"entityType": "fks",
+			"table": "backup_schedule_mirrors_table"
+		},
+		{
+			"columns": ["repository_id"],
+			"tableTo": "repositories_table",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "CASCADE",
+			"nameExplicit": false,
+			"name": "backup_schedule_mirrors_table_repository_id_repositories_table_id_fk",
+			"entityType": "fks",
+			"table": "backup_schedule_mirrors_table"
+		},
+		{
+			"columns": ["schedule_id"],
+			"tableTo": "backup_schedules_table",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "CASCADE",
+			"nameExplicit": false,
+			"name": "backup_schedule_notifications_table_schedule_id_backup_schedules_table_id_fk",
+			"entityType": "fks",
+			"table": "backup_schedule_notifications_table"
+		},
+		{
+			"columns": ["destination_id"],
+			"tableTo": "notification_destinations_table",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "CASCADE",
+			"nameExplicit": false,
+			"name": "backup_schedule_notifications_table_destination_id_notification_destinations_table_id_fk",
+			"entityType": "fks",
+			"table": "backup_schedule_notifications_table"
+		},
+		{
+			"columns": ["volume_id"],
+			"tableTo": "volumes_table",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "CASCADE",
+			"nameExplicit": false,
+			"name": "backup_schedules_table_volume_id_volumes_table_id_fk",
+			"entityType": "fks",
+			"table": "backup_schedules_table"
+		},
+		{
+			"columns": ["repository_id"],
+			"tableTo": "repositories_table",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "CASCADE",
+			"nameExplicit": false,
+			"name": "backup_schedules_table_repository_id_repositories_table_id_fk",
+			"entityType": "fks",
+			"table": "backup_schedules_table"
+		},
+		{
+			"columns": ["organization_id"],
+			"tableTo": "organization",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "CASCADE",
+			"nameExplicit": false,
+			"name": "backup_schedules_table_organization_id_organization_id_fk",
+			"entityType": "fks",
+			"table": "backup_schedules_table"
+		},
+		{
+			"columns": ["organization_id"],
+			"tableTo": "organization",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "CASCADE",
+			"nameExplicit": false,
+			"name": "invitation_organization_id_organization_id_fk",
+			"entityType": "fks",
+			"table": "invitation"
+		},
+		{
+			"columns": ["inviter_id"],
+			"tableTo": "users_table",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "CASCADE",
+			"nameExplicit": false,
+			"name": "invitation_inviter_id_users_table_id_fk",
+			"entityType": "fks",
+			"table": "invitation"
+		},
+		{
+			"columns": ["organization_id"],
+			"tableTo": "organization",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "CASCADE",
+			"nameExplicit": false,
+			"name": "member_organization_id_organization_id_fk",
+			"entityType": "fks",
+			"table": "member"
+		},
+		{
+			"columns": ["user_id"],
+			"tableTo": "users_table",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "CASCADE",
+			"nameExplicit": false,
+			"name": "member_user_id_users_table_id_fk",
+			"entityType": "fks",
+			"table": "member"
+		},
+		{
+			"columns": ["organization_id"],
+			"tableTo": "organization",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "CASCADE",
+			"nameExplicit": false,
+			"name": "notification_destinations_table_organization_id_organization_id_fk",
+			"entityType": "fks",
+			"table": "notification_destinations_table"
+		},
+		{
+			"columns": ["organization_id"],
+			"tableTo": "organization",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "CASCADE",
+			"nameExplicit": false,
+			"name": "repositories_table_organization_id_organization_id_fk",
+			"entityType": "fks",
+			"table": "repositories_table"
+		},
+		{
+			"columns": ["user_id"],
+			"tableTo": "users_table",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "CASCADE",
+			"nameExplicit": false,
+			"name": "sessions_table_user_id_users_table_id_fk",
+			"entityType": "fks",
+			"table": "sessions_table"
+		},
+		{
+			"columns": ["organization_id"],
+			"tableTo": "organization",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "CASCADE",
+			"nameExplicit": false,
+			"name": "fk_sso_provider_organization_id_organization_id_fk",
+			"entityType": "fks",
+			"table": "sso_provider"
+		},
+		{
+			"columns": ["user_id"],
+			"tableTo": "users_table",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "SET NULL",
+			"nameExplicit": false,
+			"name": "fk_sso_provider_user_id_users_table_id_fk",
+			"entityType": "fks",
+			"table": "sso_provider"
+		},
+		{
+			"columns": ["user_id"],
+			"tableTo": "users_table",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "CASCADE",
+			"nameExplicit": false,
+			"name": "two_factor_user_id_users_table_id_fk",
+			"entityType": "fks",
+			"table": "two_factor"
+		},
+		{
+			"columns": ["organization_id"],
+			"tableTo": "organization",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "CASCADE",
+			"nameExplicit": false,
+			"name": "volumes_table_organization_id_organization_id_fk",
+			"entityType": "fks",
+			"table": "volumes_table"
+		},
+		{
+			"columns": ["schedule_id", "destination_id"],
+			"nameExplicit": false,
+			"name": "backup_schedule_notifications_table_schedule_id_destination_id_pk",
+			"entityType": "pks",
+			"table": "backup_schedule_notifications_table"
+		},
+		{
+			"columns": ["id"],
+			"nameExplicit": false,
+			"name": "account_pk",
+			"table": "account",
+			"entityType": "pks"
+		},
+		{
+			"columns": ["key"],
+			"nameExplicit": false,
+			"name": "app_metadata_pk",
+			"table": "app_metadata",
+			"entityType": "pks"
+		},
+		{
+			"columns": ["id"],
+			"nameExplicit": false,
+			"name": "backup_schedule_mirrors_table_pk",
+			"table": "backup_schedule_mirrors_table",
+			"entityType": "pks"
+		},
+		{
+			"columns": ["id"],
+			"nameExplicit": false,
+			"name": "backup_schedules_table_pk",
+			"table": "backup_schedules_table",
+			"entityType": "pks"
+		},
+		{
+			"columns": ["id"],
+			"nameExplicit": false,
+			"name": "invitation_pk",
+			"table": "invitation",
+			"entityType": "pks"
+		},
+		{
+			"columns": ["id"],
+			"nameExplicit": false,
+			"name": "member_pk",
+			"table": "member",
+			"entityType": "pks"
+		},
+		{
+			"columns": ["id"],
+			"nameExplicit": false,
+			"name": "notification_destinations_table_pk",
+			"table": "notification_destinations_table",
+			"entityType": "pks"
+		},
+		{
+			"columns": ["id"],
+			"nameExplicit": false,
+			"name": "organization_pk",
+			"table": "organization",
+			"entityType": "pks"
+		},
+		{
+			"columns": ["id"],
+			"nameExplicit": false,
+			"name": "repositories_table_pk",
+			"table": "repositories_table",
+			"entityType": "pks"
+		},
+		{
+			"columns": ["id"],
+			"nameExplicit": false,
+			"name": "sessions_table_pk",
+			"table": "sessions_table",
+			"entityType": "pks"
+		},
+		{
+			"columns": ["id"],
+			"nameExplicit": false,
+			"name": "sso_provider_pk",
+			"table": "sso_provider",
+			"entityType": "pks"
+		},
+		{
+			"columns": ["id"],
+			"nameExplicit": false,
+			"name": "two_factor_pk",
+			"table": "two_factor",
+			"entityType": "pks"
+		},
+		{
+			"columns": ["id"],
+			"nameExplicit": false,
+			"name": "users_table_pk",
+			"table": "users_table",
+			"entityType": "pks"
+		},
+		{
+			"columns": ["id"],
+			"nameExplicit": false,
+			"name": "verification_pk",
+			"table": "verification",
+			"entityType": "pks"
+		},
+		{
+			"columns": ["id"],
+			"nameExplicit": false,
+			"name": "volumes_table_pk",
+			"table": "volumes_table",
+			"entityType": "pks"
+		},
+		{
+			"columns": [
+				{
+					"value": "user_id",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": null,
+			"origin": "manual",
+			"name": "account_userId_idx",
+			"entityType": "indexes",
+			"table": "account"
+		},
+		{
+			"columns": [
+				{
+					"value": "organization_id",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": null,
+			"origin": "manual",
+			"name": "invitation_organizationId_idx",
+			"entityType": "indexes",
+			"table": "invitation"
+		},
+		{
+			"columns": [
+				{
+					"value": "email",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": null,
+			"origin": "manual",
+			"name": "invitation_email_idx",
+			"entityType": "indexes",
+			"table": "invitation"
+		},
+		{
+			"columns": [
+				{
+					"value": "organization_id",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": null,
+			"origin": "manual",
+			"name": "member_organizationId_idx",
+			"entityType": "indexes",
+			"table": "member"
+		},
+		{
+			"columns": [
+				{
+					"value": "user_id",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": null,
+			"origin": "manual",
+			"name": "member_userId_idx",
+			"entityType": "indexes",
+			"table": "member"
+		},
+		{
+			"columns": [
+				{
+					"value": "organization_id",
+					"isExpression": false
+				},
+				{
+					"value": "user_id",
+					"isExpression": false
+				}
+			],
+			"isUnique": true,
+			"where": null,
+			"origin": "manual",
+			"name": "member_org_user_uidx",
+			"entityType": "indexes",
+			"table": "member"
+		},
+		{
+			"columns": [
+				{
+					"value": "slug",
+					"isExpression": false
+				}
+			],
+			"isUnique": true,
+			"where": null,
+			"origin": "manual",
+			"name": "organization_slug_uidx",
+			"entityType": "indexes",
+			"table": "organization"
+		},
+		{
+			"columns": [
+				{
+					"value": "organization_id",
+					"isExpression": false
+				},
+				{
+					"value": "provisioning_id",
+					"isExpression": false
+				}
+			],
+			"isUnique": true,
+			"where": null,
+			"origin": "manual",
+			"name": "repositories_table_org_provisioning_id_uidx",
+			"entityType": "indexes",
+			"table": "repositories_table"
+		},
+		{
+			"columns": [
+				{
+					"value": "user_id",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": null,
+			"origin": "manual",
+			"name": "sessionsTable_userId_idx",
+			"entityType": "indexes",
+			"table": "sessions_table"
+		},
+		{
+			"columns": [
+				{
+					"value": "secret",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": null,
+			"origin": "manual",
+			"name": "twoFactor_secret_idx",
+			"entityType": "indexes",
+			"table": "two_factor"
+		},
+		{
+			"columns": [
+				{
+					"value": "user_id",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": null,
+			"origin": "manual",
+			"name": "twoFactor_userId_idx",
+			"entityType": "indexes",
+			"table": "two_factor"
+		},
+		{
+			"columns": [
+				{
+					"value": "identifier",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": null,
+			"origin": "manual",
+			"name": "verification_identifier_idx",
+			"entityType": "indexes",
+			"table": "verification"
+		},
+		{
+			"columns": [
+				{
+					"value": "organization_id",
+					"isExpression": false
+				},
+				{
+					"value": "provisioning_id",
+					"isExpression": false
+				}
+			],
+			"isUnique": true,
+			"where": null,
+			"origin": "manual",
+			"name": "volumes_table_org_provisioning_id_uidx",
+			"entityType": "indexes",
+			"table": "volumes_table"
+		},
+		{
+			"columns": ["schedule_id", "repository_id"],
+			"nameExplicit": false,
+			"name": "backup_schedule_mirrors_table_schedule_id_repository_id_unique",
+			"entityType": "uniques",
+			"table": "backup_schedule_mirrors_table"
+		},
+		{
+			"columns": ["name", "organization_id"],
+			"nameExplicit": false,
+			"name": "volumes_table_name_organization_id_unique",
+			"entityType": "uniques",
+			"table": "volumes_table"
+		},
+		{
+			"columns": ["short_id"],
+			"nameExplicit": false,
+			"name": "backup_schedules_table_short_id_unique",
+			"entityType": "uniques",
+			"table": "backup_schedules_table"
+		},
+		{
+			"columns": ["short_id"],
+			"nameExplicit": false,
+			"name": "repositories_table_short_id_unique",
+			"entityType": "uniques",
+			"table": "repositories_table"
+		},
+		{
+			"columns": ["token"],
+			"nameExplicit": false,
+			"name": "sessions_table_token_unique",
+			"entityType": "uniques",
+			"table": "sessions_table"
+		},
+		{
+			"columns": ["provider_id"],
+			"nameExplicit": false,
+			"name": "sso_provider_provider_id_unique",
+			"entityType": "uniques",
+			"table": "sso_provider"
+		},
+		{
+			"columns": ["username"],
+			"nameExplicit": false,
+			"name": "users_table_username_unique",
+			"entityType": "uniques",
+			"table": "users_table"
+		},
+		{
+			"columns": ["email"],
+			"nameExplicit": false,
+			"name": "users_table_email_unique",
+			"entityType": "uniques",
+			"table": "users_table"
+		},
+		{
+			"columns": ["short_id"],
+			"nameExplicit": false,
+			"name": "volumes_table_short_id_unique",
+			"entityType": "uniques",
+			"table": "volumes_table"
+		}
+	],
+	"renames": []
+}

--- a/app/server/db/schema.ts
+++ b/app/server/db/schema.ts
@@ -311,6 +311,9 @@ export const backupSchedulesTable = sqliteTable("backup_schedules_table", {
 	oneFileSystem: int("one_file_system", { mode: "boolean" }).notNull().default(false),
 	customResticParams: text("custom_restic_params", { mode: "json" }).$type<string[]>().default([]),
 	sortOrder: int("sort_order", { mode: "number" }).notNull().default(0),
+	failureRetryCount: int("failure_retry_count").notNull().default(0),
+	maxRetries: int("max_retries").notNull().default(3),
+	retryDelay: int("retry_delay").notNull().default(3600000),
 	createdAt: int("created_at", { mode: "number" })
 		.notNull()
 		.default(sql`(unixepoch() * 1000)`),

--- a/app/server/modules/backups/backups.dto.ts
+++ b/app/server/modules/backups/backups.dto.ts
@@ -130,6 +130,8 @@ export const createBackupScheduleBody = z.object({
 	oneFileSystem: z.boolean().optional(),
 	tags: z.array(z.string()).optional(),
 	customResticParams: z.array(z.string()).optional(),
+	maxRetries: z.number().optional(),
+	retryDelay: z.number().optional(),
 });
 
 export type CreateBackupScheduleBody = z.infer<typeof createBackupScheduleBody>;
@@ -167,6 +169,8 @@ export const updateBackupScheduleBody = z.object({
 	oneFileSystem: z.boolean().optional(),
 	tags: z.array(z.string()).optional(),
 	customResticParams: z.array(z.string()).optional(),
+	maxRetries: z.number().optional(),
+	retryDelay: z.number().optional(),
 });
 
 export type UpdateBackupScheduleBody = z.infer<typeof updateBackupScheduleBody>;

--- a/app/server/modules/backups/backups.dto.ts
+++ b/app/server/modules/backups/backups.dto.ts
@@ -130,8 +130,8 @@ export const createBackupScheduleBody = z.object({
 	oneFileSystem: z.boolean().optional(),
 	tags: z.array(z.string()).optional(),
 	customResticParams: z.array(z.string()).optional(),
-	maxRetries: z.number().optional(),
-	retryDelay: z.number().optional(),
+	maxRetries: z.number().min(0).max(32).optional(),
+	retryDelay: z.number().min(1).max(1440).optional(),
 });
 
 export type CreateBackupScheduleBody = z.infer<typeof createBackupScheduleBody>;
@@ -169,8 +169,8 @@ export const updateBackupScheduleBody = z.object({
 	oneFileSystem: z.boolean().optional(),
 	tags: z.array(z.string()).optional(),
 	customResticParams: z.array(z.string()).optional(),
-	maxRetries: z.number().optional(),
-	retryDelay: z.number().optional(),
+	maxRetries: z.number().min(0).max(32).optional(),
+	retryDelay: z.number().min(1).max(1440).optional(),
 });
 
 export type UpdateBackupScheduleBody = z.infer<typeof updateBackupScheduleBody>;

--- a/app/server/modules/backups/backups.dto.ts
+++ b/app/server/modules/backups/backups.dto.ts
@@ -31,6 +31,8 @@ const backupScheduleSchema = z.object({
 	includePatterns: z.array(z.string()).nullable(),
 	oneFileSystem: z.boolean(),
 	customResticParams: z.array(z.string()).nullable(),
+	maxRetries: z.number(),
+	retryDelay: z.number(),
 	lastBackupAt: z.number().nullable(),
 	lastBackupStatus: z.enum(["success", "error", "in_progress", "warning"]).nullable(),
 	lastBackupError: z.string().nullable(),

--- a/app/server/modules/backups/backups.queries.ts
+++ b/app/server/modules/backups/backups.queries.ts
@@ -42,6 +42,7 @@ export const scheduleQueries = {
 			lastBackupAt?: number;
 			lastBackupError?: string | null;
 			nextBackupAt?: number | null;
+			failureRetryCount?: number;
 		},
 	) => {
 		return db

--- a/app/server/modules/backups/backups.service.ts
+++ b/app/server/modules/backups/backups.service.ts
@@ -111,6 +111,8 @@ const createSchedule = async (data: CreateBackupScheduleBody) => {
 			customResticParams: data.customResticParams ?? [],
 			nextBackupAt: nextBackupAt,
 			shortId: generateShortId(),
+			maxRetries: data.maxRetries,
+			retryDelay: data.retryDelay ? data.retryDelay * 60 * 1000 : undefined,
 			organizationId,
 		})
 		.returning();
@@ -163,10 +165,11 @@ const updateSchedule = async (scheduleIdOrShortId: number | string, data: Update
 	const cronExpression = data.cronExpression ?? schedule.cronExpression;
 	const nextBackupAt =
 		data.cronExpression === "" ? null : data.cronExpression ? calculateNextRun(cronExpression) : schedule.nextBackupAt;
+	const retryDelay = data.retryDelay ? data.retryDelay * 60 * 1000 : schedule.retryDelay;
 
 	const [updated] = await db
 		.update(backupSchedulesTable)
-		.set({ ...data, repositoryId: repository.id, nextBackupAt, updatedAt: Date.now() })
+		.set({ ...data, repositoryId: repository.id, nextBackupAt, updatedAt: Date.now(), retryDelay })
 		.where(and(eq(backupSchedulesTable.id, schedule.id), eq(backupSchedulesTable.organizationId, organizationId)))
 		.returning();
 

--- a/app/server/modules/backups/backups.service.ts
+++ b/app/server/modules/backups/backups.service.ts
@@ -389,7 +389,7 @@ const executeBackup = async (scheduleId: number, manual = false) => {
 	const result = await validateBackupExecution(scheduleId, manual);
 
 	if (result.type !== "success") {
-		return handleValidationResult(scheduleId, result);
+		return handleValidationResult(scheduleId, result, manual);
 	}
 
 	const { context: ctx } = result;
@@ -426,7 +426,7 @@ const executeBackup = async (scheduleId: number, manual = false) => {
 
 			switch (executionResult.status) {
 				case "unavailable":
-					return handleBackupFailure(scheduleId, ctx.organizationId, executionResult.error, ctx);
+					return handleBackupFailure(scheduleId, ctx.organizationId, executionResult.error, manual, ctx);
 				case "completed":
 					return finalizeSuccessfulBackup(
 						ctx,
@@ -435,7 +435,7 @@ const executeBackup = async (scheduleId: number, manual = false) => {
 						executionResult.warningDetails,
 					);
 				case "failed":
-					return handleBackupFailure(scheduleId, ctx.organizationId, executionResult.error, ctx);
+					return handleBackupFailure(scheduleId, ctx.organizationId, executionResult.error, manual, ctx);
 				case "cancelled":
 					return handleBackupCancellation(scheduleId, ctx.organizationId, executionResult.message);
 			}
@@ -447,7 +447,7 @@ const executeBackup = async (scheduleId: number, manual = false) => {
 			return;
 		}
 
-		return handleBackupFailure(scheduleId, ctx.organizationId, error, ctx);
+		return handleBackupFailure(scheduleId, ctx.organizationId, error, manual, ctx);
 	} finally {
 		backupExecutor.untrack(scheduleId, abortController);
 		cache.del(cacheKeys.backup.progress(scheduleId));

--- a/app/server/modules/backups/helpers/backup-lifecycle.ts
+++ b/app/server/modules/backups/helpers/backup-lifecycle.ts
@@ -225,15 +225,15 @@ export async function handleBackupFailure(
 	const currentRetryCount = schedule.failureRetryCount;
 	const maxRetries = schedule.maxRetries;
 	const shouldRetry = currentRetryCount < maxRetries;
+	const nextRetryBackupAt = Date.now() + schedule.retryDelay;
+	const nextScheduledBackupAt = calculateNextRun(schedule.cronExpression);
 
-	if (shouldRetry) {
-		const nextBackupAt = Date.now() + schedule.retryDelay;
-
+	if (shouldRetry && nextRetryBackupAt < nextScheduledBackupAt) {
 		await scheduleQueries.updateStatus(scheduleId, organizationId, {
 			lastBackupAt: Date.now(),
 			lastBackupStatus: "error",
 			lastBackupError: errorDetails,
-			nextBackupAt,
+			nextBackupAt: nextRetryBackupAt,
 			failureRetryCount: currentRetryCount + 1,
 		});
 
@@ -292,8 +292,8 @@ export async function handleBackupFailure(
 			scheduleName: schedule.name,
 			error: `${errorDetails}\n\nFailed after ${maxRetries} retry attempts.`,
 		})
-		.catch((notifError) => {
-			logger.error(`Failed to send backup failure notification: ${toMessage(notifError)}`);
+		.catch((notifyError) => {
+			logger.error(`Failed to send backup failure notification: ${toMessage(notifyError)}`);
 		});
 }
 

--- a/app/server/modules/backups/helpers/backup-lifecycle.ts
+++ b/app/server/modules/backups/helpers/backup-lifecycle.ts
@@ -85,7 +85,11 @@ export async function validateBackupExecution(scheduleId: number, manual = false
 	};
 }
 
-export async function handleValidationResult(scheduleId: number, result: ValidationFailure | ValidationSkipped) {
+export async function handleValidationResult(
+	scheduleId: number,
+	result: ValidationFailure | ValidationSkipped,
+	manual: boolean,
+) {
 	const organizationId = getOrganizationId();
 
 	if (result.type === "skipped") {
@@ -93,7 +97,7 @@ export async function handleValidationResult(scheduleId: number, result: Validat
 		return;
 	}
 
-	await handleBackupFailure(scheduleId, organizationId, result.error, result.partialContext);
+	await handleBackupFailure(scheduleId, organizationId, result.error, manual, result.partialContext);
 }
 
 export function emitBackupStarted(ctx: BackupContext, scheduleId: number) {
@@ -205,6 +209,7 @@ export async function handleBackupFailure(
 	scheduleId: number,
 	organizationId: string,
 	error: unknown,
+	manual: boolean,
 	partialContext?: Partial<BackupContext>,
 ) {
 	const errorMessage = toMessage(error);
@@ -228,7 +233,7 @@ export async function handleBackupFailure(
 	const nextRetryBackupAt = Date.now() + schedule.retryDelay;
 	const nextScheduledBackupAt = calculateNextRun(schedule.cronExpression);
 
-	if (shouldRetry && nextRetryBackupAt < nextScheduledBackupAt) {
+	if (!manual && shouldRetry && nextRetryBackupAt < nextScheduledBackupAt) {
 		await scheduleQueries.updateStatus(scheduleId, organizationId, {
 			lastBackupAt: Date.now(),
 			lastBackupStatus: "error",
@@ -273,9 +278,15 @@ export async function handleBackupFailure(
 
 	const { volume, repository } = partialContext;
 
-	logger.error(
-		`Backup ${schedule.name} failed after ${maxRetries} retries for volume ${volume.name} to repository ${repository.name}: ${errorMessage}`,
-	);
+	if (manual) {
+		logger.error(
+			`Manual backup ${schedule.name} failed for volume ${volume.name} to repository ${repository.name}: ${errorMessage}`,
+		);
+	} else {
+		logger.error(
+			`Backup ${schedule.name} failed after ${maxRetries} retries for volume ${volume.name} to repository ${repository.name}: ${errorMessage}`,
+		);
+	}
 
 	serverEvents.emit("backup:completed", {
 		organizationId,
@@ -285,12 +296,16 @@ export async function handleBackupFailure(
 		status: "error",
 	});
 
+	const errorNotificationMessage = manual
+		? `${errorDetails}`
+		: `${errorDetails}\n\nFailed after ${maxRetries} retry attempts.`;
+
 	notificationsService
 		.sendBackupNotification(scheduleId, "failure", {
 			volumeName: volume.name,
 			repositoryName: repository.name,
 			scheduleName: schedule.name,
-			error: `${errorDetails}\n\nFailed after ${maxRetries} retry attempts.`,
+			error: errorNotificationMessage,
 		})
 		.catch((notifyError) => {
 			logger.error(`Failed to send backup failure notification: ${toMessage(notifyError)}`);

--- a/app/server/modules/backups/helpers/backup-lifecycle.ts
+++ b/app/server/modules/backups/helpers/backup-lifecycle.ts
@@ -237,8 +237,10 @@ export async function handleBackupFailure(
 			failureRetryCount: currentRetryCount + 1,
 		});
 
+		const delayMinutes = Math.round((schedule.retryDelay / (60 * 1000)) * 10) / 10;
+
 		logger.warn(
-			`Backup ${schedule?.name} failed. Scheduling retry ${currentRetryCount + 1}/${maxRetries} for 1 hour from now: ${errorMessage}`,
+			`Backup ${schedule?.name} failed. Scheduling retry ${currentRetryCount + 1}/${maxRetries} for ${delayMinutes} minutes from now: ${errorMessage}`,
 		);
 
 		if (partialContext?.volume && partialContext?.repository) {
@@ -255,7 +257,7 @@ export async function handleBackupFailure(
 					volumeName: partialContext.volume.name,
 					repositoryName: partialContext.repository.name,
 					scheduleName: schedule!.name,
-					error: `${errorDetails}\n\nRetrying in 1 hour (attempt ${currentRetryCount + 1}/${maxRetries})`,
+					error: `${errorDetails}\n\nRetrying in ${delayMinutes} minutes (attempt ${currentRetryCount + 1}/${maxRetries})`,
 				})
 				.catch((notifError) => {
 					logger.error(`Failed to send backup failure notification: ${toMessage(notifError)}`);

--- a/app/server/modules/backups/helpers/backup-lifecycle.ts
+++ b/app/server/modules/backups/helpers/backup-lifecycle.ts
@@ -240,13 +240,13 @@ export async function handleBackupFailure(
 		const delayMinutes = Math.round((schedule.retryDelay / (60 * 1000)) * 10) / 10;
 
 		logger.warn(
-			`Backup ${schedule?.name} failed. Scheduling retry ${currentRetryCount + 1}/${maxRetries} for ${delayMinutes} minutes from now: ${errorMessage}`,
+			`Backup ${schedule.name} failed. Scheduling retry ${currentRetryCount + 1}/${maxRetries} for ${delayMinutes} minutes from now: ${errorMessage}`,
 		);
 
 		if (partialContext?.volume && partialContext?.repository) {
 			serverEvents.emit("backup:completed", {
 				organizationId,
-				scheduleId: schedule!.shortId,
+				scheduleId: schedule.shortId,
 				volumeName: partialContext.volume.name,
 				repositoryName: partialContext.repository.name,
 				status: "error",
@@ -256,7 +256,7 @@ export async function handleBackupFailure(
 				.sendBackupNotification(scheduleId, "failure", {
 					volumeName: partialContext.volume.name,
 					repositoryName: partialContext.repository.name,
-					scheduleName: schedule!.name,
+					scheduleName: schedule.name,
 					error: `${errorDetails}\n\nRetrying in ${delayMinutes} minutes (attempt ${currentRetryCount + 1}/${maxRetries})`,
 				})
 				.catch((notifError) => {
@@ -270,7 +270,7 @@ export async function handleBackupFailure(
 	const { volume, repository } = partialContext;
 
 	logger.error(
-		`Backup ${schedule?.name} failed after ${maxRetries} retries for volume ${volume.name} to repository ${repository.name}: ${errorMessage}`,
+		`Backup ${schedule.name} failed after ${maxRetries} retries for volume ${volume.name} to repository ${repository.name}: ${errorMessage}`,
 	);
 
 	serverEvents.emit("backup:completed", {

--- a/app/server/modules/backups/helpers/backup-lifecycle.ts
+++ b/app/server/modules/backups/helpers/backup-lifecycle.ts
@@ -267,6 +267,10 @@ export async function handleBackupFailure(
 		return;
 	}
 
+	await scheduleQueries.updateStatus(scheduleId, organizationId, {
+		failureRetryCount: 0,
+	});
+
 	const { volume, repository } = partialContext;
 
 	logger.error(

--- a/app/server/modules/backups/helpers/backup-lifecycle.ts
+++ b/app/server/modules/backups/helpers/backup-lifecycle.ts
@@ -167,6 +167,7 @@ export async function finalizeSuccessfulBackup(
 		lastBackupStatus: finalStatus,
 		lastBackupError: finalStatus === "warning" ? warningDetails : null,
 		nextBackupAt: ctx.schedule.cronExpression ? calculateNextRun(ctx.schedule.cronExpression) : null,
+		failureRetryCount: 0,
 	});
 
 	if (finalStatus === "warning") {
@@ -219,10 +220,55 @@ export async function handleBackupFailure(
 		return;
 	}
 
-	const { schedule, volume, repository } = partialContext;
+	// Determine if the backup should be retried
+	const schedule = partialContext.schedule;
+	const currentRetryCount = schedule.failureRetryCount;
+	const maxRetries = schedule.maxRetries;
+	const shouldRetry = currentRetryCount < maxRetries;
+
+	if (shouldRetry) {
+		const nextBackupAt = Date.now() + schedule.retryDelay;
+
+		await scheduleQueries.updateStatus(scheduleId, organizationId, {
+			lastBackupAt: Date.now(),
+			lastBackupStatus: "error",
+			lastBackupError: errorDetails,
+			nextBackupAt,
+			failureRetryCount: currentRetryCount + 1,
+		});
+
+		logger.warn(
+			`Backup ${schedule?.name} failed. Scheduling retry ${currentRetryCount + 1}/${maxRetries} for 1 hour from now: ${errorMessage}`,
+		);
+
+		if (partialContext?.volume && partialContext?.repository) {
+			serverEvents.emit("backup:completed", {
+				organizationId,
+				scheduleId: schedule!.shortId,
+				volumeName: partialContext.volume.name,
+				repositoryName: partialContext.repository.name,
+				status: "error",
+			});
+
+			notificationsService
+				.sendBackupNotification(scheduleId, "failure", {
+					volumeName: partialContext.volume.name,
+					repositoryName: partialContext.repository.name,
+					scheduleName: schedule!.name,
+					error: `${errorDetails}\n\nRetrying in 1 hour (attempt ${currentRetryCount + 1}/${maxRetries})`,
+				})
+				.catch((notifError) => {
+					logger.error(`Failed to send backup failure notification: ${toMessage(notifError)}`);
+				});
+		}
+
+		return;
+	}
+
+	const { volume, repository } = partialContext;
 
 	logger.error(
-		`Backup ${schedule.name} failed for volume ${volume.name} to repository ${repository.name}: ${errorMessage}`,
+		`Backup ${schedule?.name} failed after ${maxRetries} retries for volume ${volume.name} to repository ${repository.name}: ${errorMessage}`,
 	);
 
 	serverEvents.emit("backup:completed", {
@@ -238,7 +284,7 @@ export async function handleBackupFailure(
 			volumeName: volume.name,
 			repositoryName: repository.name,
 			scheduleName: schedule.name,
-			error: errorDetails,
+			error: `${errorDetails}\n\nFailed after ${maxRetries} retry attempts.`,
 		})
 		.catch((notifError) => {
 			logger.error(`Failed to send backup failure notification: ${toMessage(notifError)}`);


### PR DESCRIPTION
## Summary
This adds the option to retry the backup job if the backup failed for some reason (e.g. The target repository was not online).
It includes the option to configure for each backup job how often it should retry the failed backup and what duration will be between backups. This can be configured in the Advanced settings of the backup job. By default it will try 3 Backups in 60 minutes intervals.
if a retry of the backup failed the maximum number of times and a new scheduled backup is also failing it wont try again so it will only exhaust the maxRetries once.

## Changes
- updated backup failure states to schedule a new backup retry if needed
- updated db schema for the backup job
- integrated settings into the backup creation/edit dialog

## Testing 
I run a hourly backup local and it with 3 retry attempts and 25 minutes interval which worked fine. Resetting the failed attempt counter on successful backup also worked correctly.

## Note
I used AI to get an initial draft on how to implement it and where i need to change something. But i looked over each change and reviewed/improved it.

Closes #481

I am open for feedback. Let me know if there is anything thats not done correctly or missing and I will try to improve it.