### PR TITLE
feat: add repositories & volumes column sorting

### DIFF
--- a/app/client/components/data-table-sort-header.tsx
+++ b/app/client/components/data-table-sort-header.tsx
@@ -1,0 +1,54 @@
+import type { Column } from "@tanstack/react-table";
+import { ArrowDown, ArrowUp, ArrowUpDown } from "lucide-react";
+import { Button } from "~/client/components/ui/button";
+import { cn } from "~/client/lib/utils";
+
+export function DataTableSortHeader<TData, TValue>({
+	column,
+	title,
+	sortDirection,
+	center = false,
+}: {
+	column: Column<TData, TValue>;
+	title: string;
+	sortDirection: false | "asc" | "desc";
+	center?: boolean;
+}) {
+	const icon =
+		sortDirection === "desc" ? (
+			<ArrowDown className="ml-2 h-3.5 w-3.5" />
+		) : sortDirection === "asc" ? (
+			<ArrowUp className="ml-2 h-3.5 w-3.5" />
+		) : (
+			<ArrowUpDown className="ml-2 h-3.5 w-3.5" />
+		);
+	const iconVisibility = sortDirection ? "" : "lg:invisible lg:group-hover/sort:visible";
+
+	if (center) {
+		return (
+			<Button
+				type="button"
+				variant="ghost"
+				onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+				className="h-auto! w-full! p-0! font-inherit hover:bg-transparent uppercase group/sort relative"
+			>
+				<span className="relative flex w-full items-center justify-center">
+					{title}
+					<span className={cn("lg:absolute lg:-right-6 lg:top-1/2 lg:-translate-y-1/2", iconVisibility)}>{icon}</span>
+				</span>
+			</Button>
+		);
+	}
+
+	return (
+		<Button
+			type="button"
+			variant="ghost"
+			onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+			className="h-auto! p-0! font-inherit hover:bg-transparent uppercase group/sort"
+		>
+			{title}
+			<span className={iconVisibility}>{icon}</span>
+		</Button>
+	);
+}

--- a/app/client/components/status-dot.tsx
+++ b/app/client/components/status-dot.tsx
@@ -54,7 +54,7 @@ export const StatusDot = ({ variant, label, animated }: StatusDotProps) => {
 				</span>
 			</TooltipTrigger>
 			<TooltipContent>
-				<p>{label}</p>
+				<p className="capitalize">{label}</p>
 			</TooltipContent>
 		</Tooltip>
 	);

--- a/app/client/modules/notifications/routes/notifications.tsx
+++ b/app/client/modules/notifications/routes/notifications.tsx
@@ -129,6 +129,7 @@ export function NotificationsPage() {
 							<SelectItem value="ntfy">Ntfy</SelectItem>
 							<SelectItem value="pushover">Pushover</SelectItem>
 							<SelectItem value="telegram">Telegram</SelectItem>
+							<SelectItem value="generic">Generic</SelectItem>
 							<SelectItem value="custom">Custom</SelectItem>
 						</SelectContent>
 					</Select>

--- a/app/client/modules/notifications/routes/notifications.tsx
+++ b/app/client/modules/notifications/routes/notifications.tsx
@@ -1,6 +1,18 @@
 import { useSuspenseQuery } from "@tanstack/react-query";
+import {
+	flexRender,
+	getCoreRowModel,
+	getFilteredRowModel,
+	getSortedRowModel,
+	type ColumnDef,
+	type ColumnFiltersState,
+	type SortingState,
+	useReactTable,
+} from "@tanstack/react-table";
 import { Bell, Plus, RotateCcw } from "lucide-react";
 import { useState } from "react";
+import { listNotificationDestinationsOptions } from "~/client/api-client/@tanstack/react-query.gen";
+import { DataTableSortHeader } from "~/client/components/data-table-sort-header";
 import { EmptyState } from "~/client/components/empty-state";
 import { StatusDot } from "~/client/components/status-dot";
 import { Button } from "~/client/components/ui/button";
@@ -8,20 +20,47 @@ import { Card } from "~/client/components/ui/card";
 import { Input } from "~/client/components/ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "~/client/components/ui/select";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "~/client/components/ui/table";
-import { listNotificationDestinationsOptions } from "~/client/api-client/@tanstack/react-query.gen";
 import { useNavigate } from "@tanstack/react-router";
 import { cn } from "~/client/lib/utils";
 
-export function NotificationsPage() {
-	const [searchQuery, setSearchQuery] = useState("");
-	const [typeFilter, setTypeFilter] = useState("");
-	const [statusFilter, setStatusFilter] = useState("");
+type NotificationRow = {
+	id: number;
+	name: string;
+	type: "email" | "slack" | "discord" | "gotify" | "ntfy" | "pushover" | "telegram" | "custom" | "generic";
+	enabled: boolean;
+};
 
-	const clearFilters = () => {
-		setSearchQuery("");
-		setTypeFilter("");
-		setStatusFilter("");
-	};
+const notificationColumns: ColumnDef<NotificationRow>[] = [
+	{
+		accessorKey: "name",
+		header: ({ column }) => <DataTableSortHeader column={column} title="Name" sortDirection={column.getIsSorted()} />,
+		cell: ({ row }) => row.original.name,
+	},
+	{
+		accessorKey: "type",
+		header: ({ column }) => <DataTableSortHeader column={column} title="Type" sortDirection={column.getIsSorted()} />,
+		cell: ({ row }) => row.original.type,
+		filterFn: (row, id, value) => row.getValue(id) === value,
+	},
+	{
+		accessorFn: (row) => (row.enabled ? "enabled" : "disabled"),
+		id: "status",
+		header: ({ column }) => (
+			<DataTableSortHeader column={column} title="Status" sortDirection={column.getIsSorted()} center />
+		),
+		cell: ({ row }) => (
+			<StatusDot
+				variant={row.original.enabled ? "success" : "neutral"}
+				label={row.original.enabled ? "Enabled" : "Disabled"}
+			/>
+		),
+		filterFn: (row, id, value) => row.getValue(id) === value,
+	},
+];
+
+export function NotificationsPage() {
+	const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
+	const [sorting, setSorting] = useState<SortingState>([]);
 
 	const navigate = useNavigate();
 
@@ -29,15 +68,24 @@ export function NotificationsPage() {
 		...listNotificationDestinationsOptions(),
 	});
 
-	const filteredNotifications = data.filter((notification) => {
-		const matchesSearch = notification.name.toLowerCase().includes(searchQuery.toLowerCase());
-		const matchesType = !typeFilter || notification.type === typeFilter;
-		const matchesStatus = !statusFilter || (statusFilter === "enabled" ? notification.enabled : !notification.enabled);
-		return matchesSearch && matchesType && matchesStatus;
+	const table = useReactTable({
+		data,
+		columns: notificationColumns,
+		state: { columnFilters, sorting },
+		onColumnFiltersChange: setColumnFilters,
+		onSortingChange: setSorting,
+		getCoreRowModel: getCoreRowModel(),
+		getFilteredRowModel: getFilteredRowModel(),
+		getSortedRowModel: getSortedRowModel(),
 	});
 
+	const rows = table.getRowModel().rows;
+	const hasFilters = columnFilters.length > 0;
+
+	const clearFilters = () => table.resetColumnFilters();
+
 	const hasNoNotifications = data.length === 0;
-	const hasNoFilteredNotifications = filteredNotifications.length === 0 && !hasNoNotifications;
+	const hasNoFilteredNotifications = rows.length === 0 && !hasNoNotifications;
 
 	if (hasNoNotifications) {
 		return (
@@ -55,6 +103,10 @@ export function NotificationsPage() {
 		);
 	}
 
+	const search = (table.getColumn("name")?.getFilterValue() as string) ?? "";
+	const type = (table.getColumn("type")?.getFilterValue() as string) ?? "";
+	const status = (table.getColumn("status")?.getFilterValue() as string) ?? "";
+
 	return (
 		<Card className="p-0 gap-0">
 			<div className="flex flex-col lg:flex-row items-stretch lg:items-center gap-2 md:justify-between p-4 bg-card-header py-4">
@@ -62,10 +114,10 @@ export function NotificationsPage() {
 					<Input
 						className="w-full lg:w-45 min-w-45"
 						placeholder="Search…"
-						value={searchQuery}
-						onChange={(e) => setSearchQuery(e.target.value)}
+						value={search}
+						onChange={(e) => table.getColumn("name")?.setFilterValue(e.target.value)}
 					/>
-					<Select value={typeFilter} onValueChange={setTypeFilter}>
+					<Select value={type} onValueChange={(value) => table.getColumn("type")?.setFilterValue(value)}>
 						<SelectTrigger className="w-full lg:w-45 min-w-45">
 							<SelectValue placeholder="All types" />
 						</SelectTrigger>
@@ -80,7 +132,7 @@ export function NotificationsPage() {
 							<SelectItem value="custom">Custom</SelectItem>
 						</SelectContent>
 					</Select>
-					<Select value={statusFilter} onValueChange={setStatusFilter}>
+					<Select value={status} onValueChange={(value) => table.getColumn("status")?.setFilterValue(value)}>
 						<SelectTrigger className="w-full lg:w-45 min-w-45">
 							<SelectValue placeholder="All status" />
 						</SelectTrigger>
@@ -89,7 +141,7 @@ export function NotificationsPage() {
 							<SelectItem value="disabled">Disabled</SelectItem>
 						</SelectContent>
 					</Select>
-					{(searchQuery || typeFilter || statusFilter) && (
+					{hasFilters && (
 						<Button onClick={clearFilters} className="w-full lg:w-auto mt-2 lg:mt-0 lg:ml-2">
 							<RotateCcw className="h-4 w-4 mr-2" />
 							Clear filters
@@ -104,11 +156,22 @@ export function NotificationsPage() {
 			<div className="overflow-x-auto">
 				<Table className="border-t">
 					<TableHeader className="bg-card-header">
-						<TableRow>
-							<TableHead className="w-25 uppercase">Name</TableHead>
-							<TableHead className="uppercase text-left">Type</TableHead>
-							<TableHead className="uppercase text-center">Status</TableHead>
-						</TableRow>
+						{table.getHeaderGroups().map((headerGroup) => (
+							<TableRow key={headerGroup.id}>
+								{headerGroup.headers.map((header) => (
+									<TableHead
+										key={header.id}
+										className={cn("uppercase", {
+											"w-25": header.column.id === "name",
+											"text-left": header.column.id === "type",
+											"text-center": header.column.id === "status",
+										})}
+									>
+										{header.isPlaceholder ? null : flexRender(header.column.columnDef.header, header.getContext())}
+									</TableHead>
+								))}
+							</TableRow>
+						))}
 					</TableHeader>
 					<TableBody>
 						<TableRow className={cn({ hidden: !hasNoFilteredNotifications })}>
@@ -122,30 +185,38 @@ export function NotificationsPage() {
 								</div>
 							</TableCell>
 						</TableRow>
-						{filteredNotifications.map((notification) => (
+						{rows.map((row) => (
 							<TableRow
-								key={notification.id}
+								key={row.original.id}
 								className="hover:bg-accent/50 hover:cursor-pointer h-12"
-								onClick={() => navigate({ to: `/notifications/${notification.id}` })}
+								onClick={() => navigate({ to: `/notifications/${row.original.id}` })}
 							>
-								<TableCell className="font-medium text-strong-accent">{notification.name}</TableCell>
-								<TableCell className="capitalize text-muted-foreground">{notification.type}</TableCell>
-								<TableCell className="text-center">
-									<StatusDot
-										variant={notification.enabled ? "success" : "neutral"}
-										label={notification.enabled ? "Enabled" : "Disabled"}
-									/>
-								</TableCell>
+								{row.getVisibleCells().map((cell) => (
+									<TableCell
+										key={cell.id}
+										className={cn({
+											"font-medium text-strong-accent": cell.column.id === "name",
+											"capitalize text-muted-foreground": cell.column.id === "type",
+											"text-center": cell.column.id === "status",
+										})}
+									>
+										{flexRender(cell.column.columnDef.cell, cell.getContext())}
+									</TableCell>
+								))}
 							</TableRow>
 						))}
 					</TableBody>
 				</Table>
 			</div>
 			<div className="px-4 py-2 text-sm text-muted-foreground bg-card-header flex justify-end border-t">
-				<span>
-					<span className="text-strong-accent">{filteredNotifications.length}</span> destination
-					{filteredNotifications.length !== 1 ? "s" : ""}
-				</span>
+				{hasNoFilteredNotifications ? (
+					"No destinations match filters."
+				) : (
+					<span>
+						<span className="text-strong-accent">{rows.length}</span> destination
+						{rows.length !== 1 ? "s" : ""}
+					</span>
+				)}
 			</div>
 		</Card>
 	);

--- a/app/client/modules/repositories/routes/repositories.tsx
+++ b/app/client/modules/repositories/routes/repositories.tsx
@@ -200,11 +200,11 @@ export function RepositoriesPage() {
 									type="button"
 									variant="ghost"
 									onClick={() => toggleSort("status")}
-									className="h-auto! w-full! px-0! py-0! font-inherit hover:bg-transparent uppercase group/sort relative"
+									className="h-auto! w-full! p-0! font-inherit hover:bg-transparent uppercase group/sort relative"
 								>
 									<span className="relative flex w-full items-center justify-center">
 										Status
-										<span className="absolute -right-6 top-1/2 -translate-y-1/2 lg:invisible lg:group-hover/sort:visible">
+										<span className="lg:absolute lg:-right-6 lg:top-1/2 lg:-translate-y-1/2 lg:invisible lg:group-hover/sort:visible">
 											{renderSortIcon("status")}
 										</span>
 									</span>

--- a/app/client/modules/repositories/routes/repositories.tsx
+++ b/app/client/modules/repositories/routes/repositories.tsx
@@ -1,5 +1,5 @@
 import { useSuspenseQuery } from "@tanstack/react-query";
-import { Database, Plus, RotateCcw } from "lucide-react";
+import { ArrowDown, ArrowUp, ArrowUpDown, Database, Plus, RotateCcw } from "lucide-react";
 import { useState } from "react";
 import { listRepositoriesOptions } from "~/client/api-client/@tanstack/react-query.gen";
 import { RepositoryIcon } from "~/client/components/repository-icon";
@@ -12,11 +12,38 @@ import { cn } from "~/client/lib/utils";
 import { StatusDot } from "~/client/components/status-dot";
 import { EmptyState } from "~/client/components/empty-state";
 import { useNavigate } from "@tanstack/react-router";
+import type { RepositoryBackend } from "@zerobyte/core/restic";
+
+type SortColumn = "name" | "backend" | "status" | "compression";
+type SortDirection = "asc" | "desc";
+type RepositoryRow = {
+	id: string;
+	shortId: string;
+	name: string;
+	type: RepositoryBackend;
+	status: string | null;
+	compressionMode?: string | null;
+};
+
+const getSortValue = (column: SortColumn, repository: RepositoryRow) => {
+	switch (column) {
+		case "name":
+			return repository.name;
+		case "backend":
+			return repository.type;
+		case "status":
+			return repository.status || "";
+		case "compression":
+			return repository.compressionMode || "";
+	}
+};
 
 export function RepositoriesPage() {
 	const [searchQuery, setSearchQuery] = useState("");
 	const [statusFilter, setStatusFilter] = useState("");
 	const [backendFilter, setBackendFilter] = useState("");
+	const [sortColumn, setSortColumn] = useState<SortColumn>("name");
+	const [sortDirection, setSortDirection] = useState<SortDirection>("asc");
 
 	const clearFilters = () => {
 		setSearchQuery("");
@@ -30,15 +57,47 @@ export function RepositoriesPage() {
 		...listRepositoriesOptions(),
 	});
 
-	const filteredRepositories = data.filter((repository) => {
+	const repositories = data as RepositoryRow[];
+
+	const toggleSort = (column: SortColumn) => {
+		if (sortColumn === column) {
+			setSortDirection((prev) => (prev === "asc" ? "desc" : "asc"));
+			return;
+		}
+
+		setSortColumn(column);
+		setSortDirection("asc");
+	};
+
+	const renderSortIcon = (column: SortColumn) => {
+		if (sortColumn !== column) {
+			return <ArrowUpDown className="ml-2 h-3.5 w-3.5" />;
+		}
+
+		return sortDirection === "asc" ? (
+			<ArrowUp className="ml-2 h-3.5 w-3.5" />
+		) : (
+			<ArrowDown className="ml-2 h-3.5 w-3.5" />
+		);
+	};
+
+	const filteredRepositories = repositories.filter((repository) => {
 		const matchesSearch = repository.name.toLowerCase().includes(searchQuery.toLowerCase());
 		const matchesStatus = !statusFilter || repository.status === statusFilter;
 		const matchesBackend = !backendFilter || repository.type === backendFilter;
 		return matchesSearch && matchesStatus && matchesBackend;
 	});
 
-	const hasNoRepositories = data.length === 0;
-	const hasNoFilteredRepositories = filteredRepositories.length === 0 && !hasNoRepositories;
+	const sortedFilteredRepositories = [...filteredRepositories].sort((a, b) => {
+		const valueA = getSortValue(sortColumn, a).toLowerCase();
+		const valueB = getSortValue(sortColumn, b).toLowerCase();
+		const result = valueA.localeCompare(valueB);
+
+		return sortDirection === "asc" ? result : -result;
+	});
+
+	const hasNoRepositories = repositories.length === 0;
+	const hasNoFilteredRepositories = sortedFilteredRepositories.length === 0 && !hasNoRepositories;
 
 	if (hasNoRepositories) {
 		return (
@@ -103,10 +162,54 @@ export function RepositoriesPage() {
 				<Table className="border-t">
 					<TableHeader className="bg-card-header">
 						<TableRow>
-							<TableHead className="w-25 uppercase">Name</TableHead>
-							<TableHead className="uppercase text-left">Backend</TableHead>
-							<TableHead className="uppercase hidden sm:table-cell">Compression</TableHead>
-							<TableHead className="uppercase text-center">Status</TableHead>
+							<TableHead className="w-25 uppercase">
+								<Button
+									type="button"
+									variant="ghost"
+									onClick={() => toggleSort("name")}
+									className="h-auto! p-0! font-inherit hover:bg-transparent uppercase group/sort"
+								>
+									Name
+									<div className="lg:invisible lg:group-hover/sort:visible">{renderSortIcon("name")}</div>
+								</Button>
+							</TableHead>
+							<TableHead className="uppercase text-left">
+								<Button
+									type="button"
+									variant="ghost"
+									onClick={() => toggleSort("backend")}
+									className="h-auto! p-0! font-inherit hover:bg-transparent uppercase group/sort"
+								>
+									Backend
+									<div className="lg:invisible lg:group-hover/sort:visible">{renderSortIcon("backend")}</div>
+								</Button>
+							</TableHead>
+							<TableHead className="uppercase hidden sm:table-cell">
+								<Button
+									type="button"
+									variant="ghost"
+									onClick={() => toggleSort("compression")}
+									className="h-auto! p-0! font-inherit hover:bg-transparent uppercase group/sort"
+								>
+									Compresison
+									<div className="lg:invisible lg:group-hover/sort:visible">{renderSortIcon("compression")}</div>
+								</Button>
+							</TableHead>
+							<TableHead className="uppercase text-center">
+								<Button
+									type="button"
+									variant="ghost"
+									onClick={() => toggleSort("status")}
+									className="h-auto! w-full! px-0! py-0! font-inherit hover:bg-transparent uppercase group/sort relative"
+								>
+									<span className="relative flex w-full items-center justify-center">
+										Status
+										<span className="absolute -right-6 top-1/2 -translate-y-1/2 lg:invisible lg:group-hover/sort:visible">
+											{renderSortIcon("status")}
+										</span>
+									</span>
+								</Button>
+							</TableHead>
 						</TableRow>
 					</TableHeader>
 					<TableBody>
@@ -121,7 +224,7 @@ export function RepositoriesPage() {
 								</div>
 							</TableCell>
 						</TableRow>
-						{filteredRepositories.map((repository) => (
+						{sortedFilteredRepositories.map((repository) => (
 							<TableRow
 								key={repository.id}
 								className="hover:bg-accent/50 hover:cursor-pointer h-12"
@@ -163,8 +266,8 @@ export function RepositoriesPage() {
 					"No repositories match filters."
 				) : (
 					<span>
-						<span className="text-strong-accent">{filteredRepositories.length}</span> repositor
-						{filteredRepositories.length === 1 ? "y" : "ies"}
+						<span className="text-strong-accent">{sortedFilteredRepositories.length}</span> repositor
+						{sortedFilteredRepositories.length === 1 ? "y" : "ies"}
 					</span>
 				)}
 			</div>

--- a/app/client/modules/repositories/routes/repositories.tsx
+++ b/app/client/modules/repositories/routes/repositories.tsx
@@ -1,7 +1,18 @@
 import { useSuspenseQuery } from "@tanstack/react-query";
-import { ArrowDown, ArrowUp, ArrowUpDown, Database, Plus, RotateCcw } from "lucide-react";
+import {
+	flexRender,
+	getCoreRowModel,
+	getFilteredRowModel,
+	getSortedRowModel,
+	type ColumnDef,
+	type ColumnFiltersState,
+	type SortingState,
+	useReactTable,
+} from "@tanstack/react-table";
+import { Database, Plus, RotateCcw } from "lucide-react";
 import { useState } from "react";
 import { listRepositoriesOptions } from "~/client/api-client/@tanstack/react-query.gen";
+import { DataTableSortHeader } from "~/client/components/data-table-sort-header";
 import { RepositoryIcon } from "~/client/components/repository-icon";
 import { Button } from "~/client/components/ui/button";
 import { Card } from "~/client/components/ui/card";
@@ -14,8 +25,6 @@ import { EmptyState } from "~/client/components/empty-state";
 import { useNavigate } from "@tanstack/react-router";
 import type { RepositoryBackend } from "@zerobyte/core/restic";
 
-type SortColumn = "name" | "backend" | "status" | "compression";
-type SortDirection = "asc" | "desc";
 type RepositoryRow = {
 	id: string;
 	shortId: string;
@@ -25,31 +34,62 @@ type RepositoryRow = {
 	compressionMode?: string | null;
 };
 
-const getSortValue = (column: SortColumn, repository: RepositoryRow) => {
-	switch (column) {
-		case "name":
-			return repository.name;
-		case "backend":
-			return repository.type;
-		case "status":
-			return repository.status || "";
-		case "compression":
-			return repository.compressionMode || "";
-	}
-};
+const repositoryColumns: ColumnDef<RepositoryRow>[] = [
+	{
+		accessorKey: "name",
+		header: ({ column }) => <DataTableSortHeader column={column} title="Name" sortDirection={column.getIsSorted()} />,
+		cell: ({ row }) => (
+			<div className="flex items-center gap-2">
+				<span>{row.original.name}</span>
+			</div>
+		),
+	},
+	{
+		accessorKey: "type",
+		header: ({ column }) => (
+			<DataTableSortHeader column={column} title="Backend" sortDirection={column.getIsSorted()} />
+		),
+		cell: ({ row }) => (
+			<span className="flex items-center gap-2 text-muted-foreground">
+				<RepositoryIcon backend={row.original.type} />
+				{row.original.type}
+			</span>
+		),
+		filterFn: (row, id, value) => row.getValue(id) === value,
+	},
+	{
+		accessorFn: (row) => row.compressionMode || "off",
+		id: "compressionMode",
+		header: ({ column }) => (
+			<DataTableSortHeader column={column} title="Compression" sortDirection={column.getIsSorted()} />
+		),
+		cell: ({ row }) => (
+			<span className="text-muted-foreground text-xs bg-primary/10 rounded-md px-2 py-1">
+				{row.original.compressionMode || "off"}
+			</span>
+		),
+		sortingFn: "alphanumeric",
+	},
+	{
+		accessorFn: (row) => row.status || "unknown",
+		id: "status",
+		header: ({ column }) => (
+			<DataTableSortHeader column={column} title="Status" sortDirection={column.getIsSorted()} center />
+		),
+		cell: ({ row }) => (
+			<StatusDot
+				variant={row.original.status === "healthy" ? "success" : row.original.status === "error" ? "error" : "warning"}
+				label={row.original.status || "unknown"}
+			/>
+		),
+		sortingFn: "alphanumeric",
+		filterFn: (row, id, value) => row.getValue(id) === value,
+	},
+];
 
 export function RepositoriesPage() {
-	const [searchQuery, setSearchQuery] = useState("");
-	const [statusFilter, setStatusFilter] = useState("");
-	const [backendFilter, setBackendFilter] = useState("");
-	const [sortColumn, setSortColumn] = useState<SortColumn>("name");
-	const [sortDirection, setSortDirection] = useState<SortDirection>("asc");
-
-	const clearFilters = () => {
-		setSearchQuery("");
-		setStatusFilter("");
-		setBackendFilter("");
-	};
+	const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
+	const [sorting, setSorting] = useState<SortingState>([{ id: "name", desc: false }]);
 
 	const navigate = useNavigate();
 
@@ -59,45 +99,23 @@ export function RepositoriesPage() {
 
 	const repositories = data as RepositoryRow[];
 
-	const toggleSort = (column: SortColumn) => {
-		if (sortColumn === column) {
-			setSortDirection((prev) => (prev === "asc" ? "desc" : "asc"));
-			return;
-		}
-
-		setSortColumn(column);
-		setSortDirection("asc");
-	};
-
-	const renderSortIcon = (column: SortColumn) => {
-		if (sortColumn !== column) {
-			return <ArrowUpDown className="ml-2 h-3.5 w-3.5" />;
-		}
-
-		return sortDirection === "asc" ? (
-			<ArrowUp className="ml-2 h-3.5 w-3.5" />
-		) : (
-			<ArrowDown className="ml-2 h-3.5 w-3.5" />
-		);
-	};
-
-	const filteredRepositories = repositories.filter((repository) => {
-		const matchesSearch = repository.name.toLowerCase().includes(searchQuery.toLowerCase());
-		const matchesStatus = !statusFilter || repository.status === statusFilter;
-		const matchesBackend = !backendFilter || repository.type === backendFilter;
-		return matchesSearch && matchesStatus && matchesBackend;
+	const table = useReactTable({
+		data: repositories,
+		columns: repositoryColumns,
+		state: { columnFilters, sorting },
+		onColumnFiltersChange: setColumnFilters,
+		onSortingChange: setSorting,
+		getCoreRowModel: getCoreRowModel(),
+		getFilteredRowModel: getFilteredRowModel(),
+		getSortedRowModel: getSortedRowModel(),
 	});
+	const rows = table.getRowModel().rows;
+	const hasFilters = columnFilters.length > 0;
 
-	const sortedFilteredRepositories = [...filteredRepositories].sort((a, b) => {
-		const valueA = getSortValue(sortColumn, a).toLowerCase();
-		const valueB = getSortValue(sortColumn, b).toLowerCase();
-		const result = valueA.localeCompare(valueB);
-
-		return sortDirection === "asc" ? result : -result;
-	});
+	const clearFilters = () => table.resetColumnFilters();
 
 	const hasNoRepositories = repositories.length === 0;
-	const hasNoFilteredRepositories = sortedFilteredRepositories.length === 0 && !hasNoRepositories;
+	const hasNoFilteredRepositories = rows.length === 0 && !hasNoRepositories;
 
 	if (hasNoRepositories) {
 		return (
@@ -115,6 +133,10 @@ export function RepositoriesPage() {
 		);
 	}
 
+	const search = (table.getColumn("name")?.getFilterValue() as string) ?? "";
+	const type = (table.getColumn("type")?.getFilterValue() as string) ?? "";
+	const status = (table.getColumn("status")?.getFilterValue() as string) ?? "";
+
 	return (
 		<Card className="p-0 gap-0">
 			<div className="flex flex-col lg:flex-row items-stretch lg:items-center gap-2 md:justify-between p-4 bg-card-header py-4">
@@ -122,10 +144,10 @@ export function RepositoriesPage() {
 					<Input
 						className="w-full lg:w-45 min-w-45"
 						placeholder="Search…"
-						value={searchQuery}
-						onChange={(e) => setSearchQuery(e.target.value)}
+						value={search}
+						onChange={(e) => table.getColumn("name")?.setFilterValue(e.target.value)}
 					/>
-					<Select value={statusFilter} onValueChange={setStatusFilter}>
+					<Select value={status} onValueChange={(value) => table.getColumn("status")?.setFilterValue(value)}>
 						<SelectTrigger className="w-full lg:w-45 min-w-45">
 							<SelectValue placeholder="All status" />
 						</SelectTrigger>
@@ -135,7 +157,7 @@ export function RepositoriesPage() {
 							<SelectItem value="unknown">Unknown</SelectItem>
 						</SelectContent>
 					</Select>
-					<Select value={backendFilter} onValueChange={setBackendFilter}>
+					<Select value={type} onValueChange={(value) => table.getColumn("type")?.setFilterValue(value)}>
 						<SelectTrigger className="w-full lg:w-45 min-w-45">
 							<SelectValue placeholder="All backends" />
 						</SelectTrigger>
@@ -146,7 +168,7 @@ export function RepositoriesPage() {
 							<SelectItem value="gcs">Google Cloud Storage</SelectItem>
 						</SelectContent>
 					</Select>
-					{(searchQuery || statusFilter || backendFilter) && (
+					{hasFilters && (
 						<Button onClick={clearFilters} className="w-full lg:w-auto mt-2 lg:mt-0 lg:ml-2">
 							<RotateCcw className="h-4 w-4 mr-2" />
 							Clear filters
@@ -161,56 +183,23 @@ export function RepositoriesPage() {
 			<div className="overflow-x-auto">
 				<Table className="border-t">
 					<TableHeader className="bg-card-header">
-						<TableRow>
-							<TableHead className="w-25 uppercase">
-								<Button
-									type="button"
-									variant="ghost"
-									onClick={() => toggleSort("name")}
-									className="h-auto! p-0! font-inherit hover:bg-transparent uppercase group/sort"
-								>
-									Name
-									<div className="lg:invisible lg:group-hover/sort:visible">{renderSortIcon("name")}</div>
-								</Button>
-							</TableHead>
-							<TableHead className="uppercase text-left">
-								<Button
-									type="button"
-									variant="ghost"
-									onClick={() => toggleSort("backend")}
-									className="h-auto! p-0! font-inherit hover:bg-transparent uppercase group/sort"
-								>
-									Backend
-									<div className="lg:invisible lg:group-hover/sort:visible">{renderSortIcon("backend")}</div>
-								</Button>
-							</TableHead>
-							<TableHead className="uppercase hidden sm:table-cell">
-								<Button
-									type="button"
-									variant="ghost"
-									onClick={() => toggleSort("compression")}
-									className="h-auto! p-0! font-inherit hover:bg-transparent uppercase group/sort"
-								>
-									Compresison
-									<div className="lg:invisible lg:group-hover/sort:visible">{renderSortIcon("compression")}</div>
-								</Button>
-							</TableHead>
-							<TableHead className="uppercase text-center">
-								<Button
-									type="button"
-									variant="ghost"
-									onClick={() => toggleSort("status")}
-									className="h-auto! w-full! p-0! font-inherit hover:bg-transparent uppercase group/sort relative"
-								>
-									<span className="relative flex w-full items-center justify-center">
-										Status
-										<span className="lg:absolute lg:-right-6 lg:top-1/2 lg:-translate-y-1/2 lg:invisible lg:group-hover/sort:visible">
-											{renderSortIcon("status")}
-										</span>
-									</span>
-								</Button>
-							</TableHead>
-						</TableRow>
+						{table.getHeaderGroups().map((headerGroup) => (
+							<TableRow key={headerGroup.id}>
+								{headerGroup.headers.map((header) => (
+									<TableHead
+										key={header.id}
+										className={cn("uppercase", {
+											"w-25": header.column.id === "name",
+											"text-left": header.column.id === "type",
+											"hidden sm:table-cell": header.column.id === "compressionMode",
+											"text-center": header.column.id === "status",
+										})}
+									>
+										{header.isPlaceholder ? null : flexRender(header.column.columnDef.header, header.getContext())}
+									</TableHead>
+								))}
+							</TableRow>
+						))}
 					</TableHeader>
 					<TableBody>
 						<TableRow className={cn({ hidden: !hasNoFilteredRepositories })}>
@@ -224,38 +213,24 @@ export function RepositoriesPage() {
 								</div>
 							</TableCell>
 						</TableRow>
-						{sortedFilteredRepositories.map((repository) => (
+						{rows.map((row) => (
 							<TableRow
-								key={repository.id}
+								key={row.original.id}
 								className="hover:bg-accent/50 hover:cursor-pointer h-12"
-								onClick={() => navigate({ to: `/repositories/${repository.shortId}` })}
+								onClick={() => navigate({ to: `/repositories/${row.original.shortId}` })}
 							>
-								<TableCell className="font-medium text-strong-accent">
-									<div className="flex items-center gap-2">
-										<span>{repository.name}</span>
-									</div>
-								</TableCell>
-								<TableCell>
-									<span className="flex items-center gap-2 text-muted-foreground">
-										<RepositoryIcon backend={repository.type} />
-										{repository.type}
-									</span>
-								</TableCell>
-								<TableCell className="hidden sm:table-cell">
-									<span className="text-muted-foreground text-xs bg-primary/10 rounded-md px-2 py-1">
-										{repository.compressionMode || "off"}
-									</span>
-								</TableCell>
-								<TableCell className="text-center">
-									<StatusDot
-										variant={
-											repository.status === "healthy" ? "success" : repository.status === "error" ? "error" : "warning"
-										}
-										label={
-											repository.status ? repository.status[0].toUpperCase() + repository.status.slice(1) : "Unknown"
-										}
-									/>
-								</TableCell>
+								{row.getVisibleCells().map((cell) => (
+									<TableCell
+										key={cell.id}
+										className={cn({
+											"font-medium text-strong-accent": cell.column.id === "name",
+											"hidden sm:table-cell": cell.column.id === "compressionMode",
+											"text-center": cell.column.id === "status",
+										})}
+									>
+										{flexRender(cell.column.columnDef.cell, cell.getContext())}
+									</TableCell>
+								))}
 							</TableRow>
 						))}
 					</TableBody>
@@ -266,8 +241,8 @@ export function RepositoriesPage() {
 					"No repositories match filters."
 				) : (
 					<span>
-						<span className="text-strong-accent">{sortedFilteredRepositories.length}</span> repositor
-						{sortedFilteredRepositories.length === 1 ? "y" : "ies"}
+						<span className="text-strong-accent">{rows.length}</span> repositor
+						{rows.length === 1 ? "y" : "ies"}
 					</span>
 				)}
 			</div>

--- a/app/client/modules/repositories/routes/repositories.tsx
+++ b/app/client/modules/repositories/routes/repositories.tsx
@@ -97,10 +97,8 @@ export function RepositoriesPage() {
 		...listRepositoriesOptions(),
 	});
 
-	const repositories = data as RepositoryRow[];
-
 	const table = useReactTable({
-		data: repositories,
+		data,
 		columns: repositoryColumns,
 		state: { columnFilters, sorting },
 		onColumnFiltersChange: setColumnFilters,
@@ -114,7 +112,7 @@ export function RepositoriesPage() {
 
 	const clearFilters = () => table.resetColumnFilters();
 
-	const hasNoRepositories = repositories.length === 0;
+	const hasNoRepositories = data.length === 0;
 	const hasNoFilteredRepositories = rows.length === 0 && !hasNoRepositories;
 
 	if (hasNoRepositories) {

--- a/app/client/modules/volumes/routes/volumes.tsx
+++ b/app/client/modules/volumes/routes/volumes.tsx
@@ -1,5 +1,5 @@
 import { useSuspenseQuery } from "@tanstack/react-query";
-import { HardDrive, Plus, RotateCcw } from "lucide-react";
+import { ArrowDown, ArrowUp, ArrowUpDown, HardDrive, Plus, RotateCcw } from "lucide-react";
 import { useState } from "react";
 import { EmptyState } from "~/client/components/empty-state";
 import { StatusDot } from "~/client/components/status-dot";
@@ -24,10 +24,32 @@ const getVolumeStatusVariant = (status: VolumeStatus): "success" | "neutral" | "
 	return statusMap[status];
 };
 
+type SortColumn = "name" | "backend" | "status";
+type SortDirection = "asc" | "desc";
+type VolumeRow = {
+	shortId: string;
+	name: string;
+	type: "directory" | "nfs" | "smb" | "webdav" | "sftp" | "rclone";
+	status: VolumeStatus;
+};
+
+const getSortValue = (column: SortColumn, volume: VolumeRow) => {
+	switch (column) {
+		case "name":
+			return volume.name;
+		case "backend":
+			return volume.type;
+		case "status":
+			return volume.status;
+	}
+};
+
 export function VolumesPage() {
 	const [searchQuery, setSearchQuery] = useState("");
 	const [statusFilter, setStatusFilter] = useState("");
 	const [backendFilter, setBackendFilter] = useState("");
+	const [sortColumn, setSortColumn] = useState<SortColumn>("name");
+	const [sortDirection, setSortDirection] = useState<SortDirection>("asc");
 
 	const clearFilters = () => {
 		setSearchQuery("");
@@ -41,16 +63,48 @@ export function VolumesPage() {
 		...listVolumesOptions(),
 	});
 
+	const volumes = data as VolumeRow[];
+
+	const toggleSort = (column: SortColumn) => {
+		if (sortColumn === column) {
+			setSortDirection((prev) => (prev === "asc" ? "desc" : "asc"));
+			return;
+		}
+
+		setSortColumn(column);
+		setSortDirection("asc");
+	};
+
+	const renderSortIcon = (column: SortColumn) => {
+		if (sortColumn !== column) {
+			return <ArrowUpDown className="ml-2 h-3.5 w-3.5" />;
+		}
+
+		return sortDirection === "asc" ? (
+			<ArrowUp className="ml-2 h-3.5 w-3.5" />
+		) : (
+			<ArrowDown className="ml-2 h-3.5 w-3.5" />
+		);
+	};
+
 	const filteredVolumes =
-		data.filter((volume) => {
+		volumes.filter((volume) => {
 			const matchesSearch = volume.name.toLowerCase().includes(searchQuery.toLowerCase());
 			const matchesStatus = !statusFilter || volume.status === statusFilter;
 			const matchesBackend = !backendFilter || volume.type === backendFilter;
 			return matchesSearch && matchesStatus && matchesBackend;
 		}) || [];
 
-	const hasNoVolumes = data.length === 0;
-	const hasNoFilteredVolumes = filteredVolumes.length === 0 && !hasNoVolumes;
+	const sortedFilteredVolumes = [...filteredVolumes].sort((a, b) => {
+		const valueA = getSortValue(sortColumn, a).toLowerCase();
+		const valueB = getSortValue(sortColumn, b).toLowerCase();
+		const result = valueA.localeCompare(valueB);
+
+		return sortDirection === "asc" ? result : -result;
+	});
+
+	const hasNoVolumes = volumes.length === 0;
+	const hasNoFilteredVolumes = sortedFilteredVolumes.length === 0 && !hasNoVolumes;
 
 	if (hasNoVolumes) {
 		return (
@@ -117,9 +171,43 @@ export function VolumesPage() {
 				<Table className="border-t">
 					<TableHeader className="bg-card-header">
 						<TableRow>
-							<TableHead className="w-25 uppercase">Name</TableHead>
-							<TableHead className="uppercase text-left">Backend</TableHead>
-							<TableHead className="uppercase text-center">Status</TableHead>
+							<TableHead className="w-25 uppercase group/sort">
+								<Button
+									type="button"
+									variant="ghost"
+									onClick={() => toggleSort("name")}
+									className="h-auto! p-0! font-inherit hover:bg-transparent uppercase group/sort"
+								>
+									Name
+									<div className="lg:invisible lg:group-hover/sort:visible">{renderSortIcon("name")}</div>
+								</Button>
+							</TableHead>
+							<TableHead className="uppercase text-left">
+								<Button
+									type="button"
+									variant="ghost"
+									onClick={() => toggleSort("backend")}
+									className="h-auto! p-0! font-inherit hover:bg-transparent uppercase group/sort"
+								>
+									Backend
+									<div className="lg:invisible lg:group-hover/sort:visible">{renderSortIcon("backend")}</div>
+								</Button>
+							</TableHead>
+							<TableHead className="uppercase text-center">
+								<Button
+									type="button"
+									variant="ghost"
+									onClick={() => toggleSort("status")}
+									className="h-auto! p-0! font-inherit hover:bg-transparent uppercase group/sort relative"
+								>
+									<span className="relative flex w-full items-center justify-center">
+										Status
+										<span className="lg:absolute lg:-right-6 lg:top-1/2 lg:-translate-y-1/2 lg:invisible lg:group-hover/sort:visible">
+											{renderSortIcon("status")}
+										</span>
+									</span>
+								</Button>
+							</TableHead>
 						</TableRow>
 					</TableHeader>
 					<TableBody>
@@ -134,7 +222,7 @@ export function VolumesPage() {
 								</div>
 							</TableCell>
 						</TableRow>
-						{filteredVolumes.map((volume) => (
+						{sortedFilteredVolumes.map((volume) => (
 							<TableRow
 								key={volume.shortId}
 								className="hover:bg-muted/50 hover:cursor-pointer transition-colors h-12"
@@ -164,8 +252,8 @@ export function VolumesPage() {
 					"No volumes match filters."
 				) : (
 					<span className="font-mono">
-						<span className="text-strong-accent font-bold">{filteredVolumes.length}</span> volume
-						{filteredVolumes.length > 1 ? "s" : ""}
+						<span className="text-strong-accent font-bold">{sortedFilteredVolumes.length}</span> volume
+						{sortedFilteredVolumes.length > 1 ? "s" : ""}
 					</span>
 				)}
 			</div>

--- a/app/client/modules/volumes/routes/volumes.tsx
+++ b/app/client/modules/volumes/routes/volumes.tsx
@@ -1,6 +1,18 @@
 import { useSuspenseQuery } from "@tanstack/react-query";
-import { ArrowDown, ArrowUp, ArrowUpDown, HardDrive, Plus, RotateCcw } from "lucide-react";
+import {
+	flexRender,
+	getCoreRowModel,
+	getFilteredRowModel,
+	getSortedRowModel,
+	type ColumnDef,
+	type ColumnFiltersState,
+	type SortingState,
+	useReactTable,
+} from "@tanstack/react-table";
+import { HardDrive, Plus, RotateCcw } from "lucide-react";
 import { useState } from "react";
+import { listVolumesOptions } from "~/client/api-client/@tanstack/react-query.gen";
+import { DataTableSortHeader } from "~/client/components/data-table-sort-header";
 import { EmptyState } from "~/client/components/empty-state";
 import { StatusDot } from "~/client/components/status-dot";
 import { Button } from "~/client/components/ui/button";
@@ -9,7 +21,6 @@ import { Input } from "~/client/components/ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "~/client/components/ui/select";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "~/client/components/ui/table";
 import { VolumeIcon } from "~/client/components/volume-icon";
-import { listVolumesOptions } from "~/client/api-client/@tanstack/react-query.gen";
 import type { VolumeStatus } from "~/client/lib/types";
 import { useNavigate } from "@tanstack/react-router";
 import { cn } from "~/client/lib/utils";
@@ -24,8 +35,6 @@ const getVolumeStatusVariant = (status: VolumeStatus): "success" | "neutral" | "
 	return statusMap[status];
 };
 
-type SortColumn = "name" | "backend" | "status";
-type SortDirection = "asc" | "desc";
 type VolumeRow = {
 	shortId: string;
 	name: string;
@@ -33,78 +42,61 @@ type VolumeRow = {
 	status: VolumeStatus;
 };
 
-const getSortValue = (column: SortColumn, volume: VolumeRow) => {
-	switch (column) {
-		case "name":
-			return volume.name;
-		case "backend":
-			return volume.type;
-		case "status":
-			return volume.status;
-	}
-};
+const volumeColumns: ColumnDef<VolumeRow>[] = [
+	{
+		accessorKey: "name",
+		header: ({ column }) => <DataTableSortHeader column={column} title="Name" sortDirection={column.getIsSorted()} />,
+		cell: ({ row }) => (
+			<div className="flex items-center gap-2">
+				<span>{row.original.name}</span>
+			</div>
+		),
+	},
+	{
+		accessorKey: "type",
+		header: ({ column }) => (
+			<DataTableSortHeader column={column} title="Backend" sortDirection={column.getIsSorted()} />
+		),
+		cell: ({ row }) => <VolumeIcon backend={row.original.type} />,
+		filterFn: (row, id, value) => row.getValue(id) === value,
+	},
+	{
+		accessorKey: "status",
+		header: ({ column }) => (
+			<DataTableSortHeader column={column} title="Status" sortDirection={column.getIsSorted()} center />
+		),
+		cell: ({ row }) => <StatusDot variant={getVolumeStatusVariant(row.original.status)} label={row.original.status} />,
+		filterFn: (row, id, value) => row.getValue(id) === value,
+	},
+];
 
 export function VolumesPage() {
-	const [searchQuery, setSearchQuery] = useState("");
-	const [statusFilter, setStatusFilter] = useState("");
-	const [backendFilter, setBackendFilter] = useState("");
-	const [sortColumn, setSortColumn] = useState<SortColumn>("name");
-	const [sortDirection, setSortDirection] = useState<SortDirection>("asc");
-
-	const clearFilters = () => {
-		setSearchQuery("");
-		setStatusFilter("");
-		setBackendFilter("");
-	};
+	const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
+	const [sorting, setSorting] = useState<SortingState>([]);
 
 	const navigate = useNavigate();
-
-	const { data } = useSuspenseQuery({
-		...listVolumesOptions(),
-	});
+	const { data } = useSuspenseQuery({ ...listVolumesOptions() });
 
 	const volumes = data as VolumeRow[];
 
-	const toggleSort = (column: SortColumn) => {
-		if (sortColumn === column) {
-			setSortDirection((prev) => (prev === "asc" ? "desc" : "asc"));
-			return;
-		}
-
-		setSortColumn(column);
-		setSortDirection("asc");
-	};
-
-	const renderSortIcon = (column: SortColumn) => {
-		if (sortColumn !== column) {
-			return <ArrowUpDown className="ml-2 h-3.5 w-3.5" />;
-		}
-
-		return sortDirection === "asc" ? (
-			<ArrowUp className="ml-2 h-3.5 w-3.5" />
-		) : (
-			<ArrowDown className="ml-2 h-3.5 w-3.5" />
-		);
-	};
-
-	const filteredVolumes =
-		volumes.filter((volume) => {
-			const matchesSearch = volume.name.toLowerCase().includes(searchQuery.toLowerCase());
-			const matchesStatus = !statusFilter || volume.status === statusFilter;
-			const matchesBackend = !backendFilter || volume.type === backendFilter;
-			return matchesSearch && matchesStatus && matchesBackend;
-		}) || [];
-
-	const sortedFilteredVolumes = [...filteredVolumes].sort((a, b) => {
-		const valueA = getSortValue(sortColumn, a).toLowerCase();
-		const valueB = getSortValue(sortColumn, b).toLowerCase();
-		const result = valueA.localeCompare(valueB);
-
-		return sortDirection === "asc" ? result : -result;
+	const table = useReactTable({
+		data: volumes,
+		columns: volumeColumns,
+		state: { columnFilters, sorting },
+		onColumnFiltersChange: setColumnFilters,
+		onSortingChange: setSorting,
+		getCoreRowModel: getCoreRowModel(),
+		getFilteredRowModel: getFilteredRowModel(),
+		getSortedRowModel: getSortedRowModel(),
 	});
 
+	const rows = table.getRowModel().rows;
+	const hasFilters = columnFilters.length > 0;
+
+	const clearFilters = () => table.resetColumnFilters();
+
 	const hasNoVolumes = volumes.length === 0;
-	const hasNoFilteredVolumes = sortedFilteredVolumes.length === 0 && !hasNoVolumes;
+	const hasNoFilteredVolumes = rows.length === 0 && !hasNoVolumes;
 
 	if (hasNoVolumes) {
 		return (
@@ -122,6 +114,10 @@ export function VolumesPage() {
 		);
 	}
 
+	const search = (table.getColumn("name")?.getFilterValue() as string) ?? "";
+	const status = (table.getColumn("status")?.getFilterValue() as string) ?? "";
+	const type = (table.getColumn("type")?.getFilterValue() as string) ?? "";
+
 	return (
 		<Card className="p-0 gap-0">
 			<div className="flex flex-col lg:flex-row items-stretch lg:items-center gap-2 md:justify-between p-4 bg-card-header py-4">
@@ -129,10 +125,10 @@ export function VolumesPage() {
 					<Input
 						className="w-full lg:w-45 min-w-45"
 						placeholder="Search…"
-						value={searchQuery}
-						onChange={(e) => setSearchQuery(e.target.value)}
+						value={search}
+						onChange={(e) => table.getColumn("name")?.setFilterValue(e.target.value)}
 					/>
-					<Select value={statusFilter} onValueChange={setStatusFilter}>
+					<Select value={status} onValueChange={(value) => table.getColumn("status")?.setFilterValue(value)}>
 						<SelectTrigger className="w-full lg:w-45 min-w-45">
 							<SelectValue placeholder="All status" />
 						</SelectTrigger>
@@ -142,7 +138,7 @@ export function VolumesPage() {
 							<SelectItem value="error">Error</SelectItem>
 						</SelectContent>
 					</Select>
-					<Select value={backendFilter} onValueChange={setBackendFilter}>
+					<Select value={type} onValueChange={(value) => table.getColumn("type")?.setFilterValue(value)}>
 						<SelectTrigger className="w-full lg:w-45 min-w-45">
 							<SelectValue placeholder="All backends" />
 						</SelectTrigger>
@@ -155,7 +151,7 @@ export function VolumesPage() {
 							<SelectItem value="rclone">rclone</SelectItem>
 						</SelectContent>
 					</Select>
-					{(searchQuery || statusFilter || backendFilter) && (
+					{hasFilters && (
 						<Button onClick={clearFilters} className="w-full lg:w-auto mt-2 lg:mt-0 lg:ml-2">
 							<RotateCcw className="h-4 w-4 mr-2" />
 							Clear filters
@@ -170,49 +166,26 @@ export function VolumesPage() {
 			<div className="overflow-x-auto">
 				<Table className="border-t">
 					<TableHeader className="bg-card-header">
-						<TableRow>
-							<TableHead className="w-25 uppercase group/sort">
-								<Button
-									type="button"
-									variant="ghost"
-									onClick={() => toggleSort("name")}
-									className="h-auto! p-0! font-inherit hover:bg-transparent uppercase group/sort"
-								>
-									Name
-									<div className="lg:invisible lg:group-hover/sort:visible">{renderSortIcon("name")}</div>
-								</Button>
-							</TableHead>
-							<TableHead className="uppercase text-left">
-								<Button
-									type="button"
-									variant="ghost"
-									onClick={() => toggleSort("backend")}
-									className="h-auto! p-0! font-inherit hover:bg-transparent uppercase group/sort"
-								>
-									Backend
-									<div className="lg:invisible lg:group-hover/sort:visible">{renderSortIcon("backend")}</div>
-								</Button>
-							</TableHead>
-							<TableHead className="uppercase text-center">
-								<Button
-									type="button"
-									variant="ghost"
-									onClick={() => toggleSort("status")}
-									className="h-auto! p-0! font-inherit hover:bg-transparent uppercase group/sort relative"
-								>
-									<span className="relative flex w-full items-center justify-center">
-										Status
-										<span className="lg:absolute lg:-right-6 lg:top-1/2 lg:-translate-y-1/2 lg:invisible lg:group-hover/sort:visible">
-											{renderSortIcon("status")}
-										</span>
-									</span>
-								</Button>
-							</TableHead>
-						</TableRow>
+						{table.getHeaderGroups().map((headerGroup) => (
+							<TableRow key={headerGroup.id}>
+								{headerGroup.headers.map((header) => (
+									<TableHead
+										key={header.id}
+										className={cn("uppercase", {
+											"w-25": header.column.id === "name",
+											"text-left": header.column.id === "type",
+											"text-center": header.column.id === "status",
+										})}
+									>
+										{header.isPlaceholder ? null : flexRender(header.column.columnDef.header, header.getContext())}
+									</TableHead>
+								))}
+							</TableRow>
+						))}
 					</TableHeader>
 					<TableBody>
 						<TableRow className={cn({ hidden: !hasNoFilteredVolumes })}>
-							<TableCell colSpan={4} className="text-center py-12">
+							<TableCell colSpan={3} className="text-center py-12">
 								<div className="flex flex-col items-center gap-3">
 									<p className="text-muted-foreground">No volumes match your filters.</p>
 									<Button onClick={clearFilters} variant="outline" size="sm">
@@ -222,26 +195,24 @@ export function VolumesPage() {
 								</div>
 							</TableCell>
 						</TableRow>
-						{sortedFilteredVolumes.map((volume) => (
+						{rows.map((row) => (
 							<TableRow
-								key={volume.shortId}
+								key={row.original.shortId}
 								className="hover:bg-muted/50 hover:cursor-pointer transition-colors h-12"
-								onClick={() => navigate({ to: `/volumes/${volume.shortId}` })}
+								onClick={() => navigate({ to: `/volumes/${row.original.shortId}` })}
 							>
-								<TableCell className="font-medium font-mono text-strong-accent">
-									<div className="flex items-center gap-2">
-										<span>{volume.name}</span>
-									</div>
-								</TableCell>
-								<TableCell className="font-mono text-muted-foreground">
-									<VolumeIcon backend={volume.type} />
-								</TableCell>
-								<TableCell className="text-center font-mono">
-									<StatusDot
-										variant={getVolumeStatusVariant(volume.status)}
-										label={volume.status[0].toUpperCase() + volume.status.slice(1)}
-									/>
-								</TableCell>
+								{row.getVisibleCells().map((cell) => (
+									<TableCell
+										key={cell.id}
+										className={cn("font-mono", {
+											"font-medium text-strong-accent": cell.column.id === "name",
+											"text-muted-foreground": cell.column.id === "type",
+											"text-center": cell.column.id === "status",
+										})}
+									>
+										{flexRender(cell.column.columnDef.cell, cell.getContext())}
+									</TableCell>
+								))}
 							</TableRow>
 						))}
 					</TableBody>
@@ -252,8 +223,8 @@ export function VolumesPage() {
 					"No volumes match filters."
 				) : (
 					<span className="font-mono">
-						<span className="text-strong-accent font-bold">{sortedFilteredVolumes.length}</span> volume
-						{sortedFilteredVolumes.length > 1 ? "s" : ""}
+						<span className="text-strong-accent font-bold">{rows.length}</span> volume
+						{rows.length > 1 ? "s" : ""}
 					</span>
 				)}
 			</div>

--- a/app/client/modules/volumes/routes/volumes.tsx
+++ b/app/client/modules/volumes/routes/volumes.tsx
@@ -77,10 +77,8 @@ export function VolumesPage() {
 	const navigate = useNavigate();
 	const { data } = useSuspenseQuery({ ...listVolumesOptions() });
 
-	const volumes = data as VolumeRow[];
-
 	const table = useReactTable({
-		data: volumes,
+		data,
 		columns: volumeColumns,
 		state: { columnFilters, sorting },
 		onColumnFiltersChange: setColumnFilters,
@@ -95,7 +93,7 @@ export function VolumesPage() {
 
 	const clearFilters = () => table.resetColumnFilters();
 
-	const hasNoVolumes = volumes.length === 0;
+	const hasNoVolumes = data.length === 0;
 	const hasNoFilteredVolumes = rows.length === 0 && !hasNoVolumes;
 
 	if (hasNoVolumes) {

--- a/bun.lock
+++ b/bun.lock
@@ -34,6 +34,7 @@
         "@tanstack/react-router": "^1.168.1",
         "@tanstack/react-router-ssr-query": "^1.166.10",
         "@tanstack/react-start": "^1.167.1",
+        "@tanstack/react-table": "^8.21.3",
         "@zerobyte/contracts": "workspace:*",
         "@zerobyte/core": "workspace:*",
         "better-auth": "^1.5.5",
@@ -1246,6 +1247,8 @@
 
     "@tanstack/react-store": ["@tanstack/react-store@0.9.3", "", { "dependencies": { "@tanstack/store": "0.9.3", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-y2iHd/N9OkoQbFJLUX1T9vbc2O9tjH0pQRgTcx1/Nz4IlwLvkgpuglXUx+mXt0g5ZDFrEeDnONPqkbfxXJKwRg=="],
 
+    "@tanstack/react-table": ["@tanstack/react-table@8.21.3", "", { "dependencies": { "@tanstack/table-core": "8.21.3" }, "peerDependencies": { "react": ">=16.8", "react-dom": ">=16.8" } }, "sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww=="],
+
     "@tanstack/router-core": ["@tanstack/router-core@1.168.1", "", { "dependencies": { "@tanstack/history": "1.161.6", "cookie-es": "^2.0.0", "seroval": "^1.4.2", "seroval-plugins": "^1.4.2", "tiny-invariant": "^1.3.3", "tiny-warning": "^1.0.3" }, "bin": { "intent": "bin/intent.js" } }, "sha512-RtpshTLZsMOkwW7rI52WFWGZSSfMAyDR1zWP9kVm91UX28gedc+LXih1CTP6TchS+TvxK4q8oW7ApMTvnpiY1w=="],
 
     "@tanstack/router-devtools-core": ["@tanstack/router-devtools-core@1.167.3", "", { "dependencies": { "clsx": "^2.1.1", "goober": "^2.1.16" }, "peerDependencies": { "@tanstack/router-core": "^1.168.11", "csstype": "^3.0.10" }, "optionalPeers": ["csstype"] }, "sha512-fJ1VMhyQgnoashTrP763c2HRc9kofgF61L7Jb3F6eTHAmCKtGVx8BRtiFt37sr3U0P0jmaaiiSPGP6nT5JtVNg=="],
@@ -1269,6 +1272,8 @@
     "@tanstack/start-storage-context": ["@tanstack/start-storage-context@1.166.15", "", { "dependencies": { "@tanstack/router-core": "1.168.1" } }, "sha512-mGDNfJo/eFtwgFFBrJ85rNdIBNTroE3zy5zbwHZ/FV0HPYOawnev7KscDjKBuVxBGY2jl0fQLrRNUO/Sjqy3cg=="],
 
     "@tanstack/store": ["@tanstack/store@0.9.3", "", {}, "sha512-8reSzl/qGWGGVKhBoxXPMWzATSbZLZFWhwBAFO9NAyp0TxzfBP0mIrGb8CP8KrQTmvzXlR/vFPPUrHTLBGyFyw=="],
+
+    "@tanstack/table-core": ["@tanstack/table-core@8.21.3", "", {}, "sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg=="],
 
     "@tanstack/virtual-file-routes": ["@tanstack/virtual-file-routes@1.161.7", "", { "bin": { "intent": "bin/intent.js" } }, "sha512-olW33+Cn+bsCsZKPwEGhlkqS6w3M2slFv11JIobdnCFKMLG97oAI2kWKdx5/zsywTL8flpnoIgaZZPlQTFYhdQ=="],
 

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
 		"@tanstack/react-router": "^1.168.1",
 		"@tanstack/react-router-ssr-query": "^1.166.10",
 		"@tanstack/react-start": "^1.167.1",
+		"@tanstack/react-table": "^8.21.3",
 		"@zerobyte/contracts": "workspace:*",
 		"@zerobyte/core": "workspace:*",
 		"better-auth": "^1.5.5",


### PR DESCRIPTION
A proposition to solve #788 issue by adding sorting to columns on Volumes & Repositories pages.
- Displays sorting arrows on column title hover on lg+ screens
- Adds the arrows on smaller screens without hovering
- Preserving the initial titles spacing & centering

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced table sorting and filtering across Notifications, Repositories, and Volumes pages with improved responsiveness and consistency.

* **Style**
  * Updated status indicator tooltip styling for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->