### PR TITLE
feat: add UI ssh key pair generator

### DIFF
--- a/app/client/modules/repositories/components/repository-forms/sftp-repository-form.tsx
+++ b/app/client/modules/repositories/components/repository-forms/sftp-repository-form.tsx
@@ -1,4 +1,5 @@
 import { useWatch, type UseFormReturn } from "react-hook-form";
+import { useState } from "react";
 import {
 	FormControl,
 	FormDescription,
@@ -11,6 +12,8 @@ import { Input } from "../../../../components/ui/input";
 import { Textarea } from "../../../../components/ui/textarea";
 import { Switch } from "../../../../components/ui/switch";
 import type { RepositoryFormValues } from "../create-repository-form";
+import { Button } from "~/client/components/ui/button";
+import { generatePrivateKeyPem } from "~/utils/ssh";
 
 type Props = {
 	form: UseFormReturn<RepositoryFormValues>;
@@ -18,6 +21,26 @@ type Props = {
 
 export const SftpRepositoryForm = ({ form }: Props) => {
 	const skipHostKeyCheck = useWatch({ control: form.control, name: "skipHostKeyCheck" });
+	const [isGeneratingKey, setIsGeneratingKey] = useState(false);
+	const [keyGenerationError, setKeyGenerationError] = useState<string | null>(null);
+
+	const handleGenerateKey = async () => {
+		setIsGeneratingKey(true);
+		setKeyGenerationError(null);
+
+		try {
+			const privateKey = await generatePrivateKeyPem();
+			form.setValue("privateKey", privateKey, {
+				shouldDirty: true,
+				shouldTouch: true,
+				shouldValidate: true,
+			});
+		} catch {
+			setKeyGenerationError("Could not generate SSH key in this browser.");
+		} finally {
+			setIsGeneratingKey(false);
+		}
+	};
 
 	return (
 		<>
@@ -96,6 +119,17 @@ export const SftpRepositoryForm = ({ form }: Props) => {
 						</FormControl>
 						<FormDescription>Paste the contents of your SSH private key.</FormDescription>
 						<FormMessage />
+						<Button
+							type="button"
+							variant="outline"
+							size="sm"
+							onClick={() => void handleGenerateKey()}
+							disabled={isGeneratingKey}
+						>
+							{isGeneratingKey ? "Generating..." : "Generate SSH Private Key"}
+						</Button>
+						<FormDescription>The key is generated privately in your browser. Don't forget to save it!</FormDescription>
+						{keyGenerationError && <FormMessage className="text-xs text-destructive">{keyGenerationError}</FormMessage>}
 					</FormItem>
 				)}
 			/>

--- a/app/client/modules/repositories/components/repository-forms/sftp-repository-form.tsx
+++ b/app/client/modules/repositories/components/repository-forms/sftp-repository-form.tsx
@@ -13,7 +13,7 @@ import { Textarea } from "../../../../components/ui/textarea";
 import { Switch } from "../../../../components/ui/switch";
 import type { RepositoryFormValues } from "../create-repository-form";
 import { Button } from "~/client/components/ui/button";
-import { generatePrivateKeyPem } from "~/utils/ssh";
+import { generatePrivateKeyPem, generateSshKeyPairPem } from "~/utils/ssh";
 
 type Props = {
 	form: UseFormReturn<RepositoryFormValues>;
@@ -23,22 +23,40 @@ export const SftpRepositoryForm = ({ form }: Props) => {
 	const skipHostKeyCheck = useWatch({ control: form.control, name: "skipHostKeyCheck" });
 	const [isGeneratingKey, setIsGeneratingKey] = useState(false);
 	const [keyGenerationError, setKeyGenerationError] = useState<string | null>(null);
+	const [generatedPublicKey, setGeneratedPublicKey] = useState<string | null>(null);
+	const [copyPublicKeyMessage, setCopyPublicKeyMessage] = useState<string | null>(null);
 
 	const handleGenerateKey = async () => {
 		setIsGeneratingKey(true);
 		setKeyGenerationError(null);
 
 		try {
-			const privateKey = await generatePrivateKeyPem();
-			form.setValue("privateKey", privateKey, {
+			const { privateKeyPem, publicKeyPem } = await generateSshKeyPairPem();
+			form.setValue("privateKey", privateKeyPem, {
 				shouldDirty: true,
 				shouldTouch: true,
 				shouldValidate: true,
 			});
+			setGeneratedPublicKey(publicKeyPem);
 		} catch {
+			setGeneratedPublicKey(null);
 			setKeyGenerationError("Could not generate SSH key in this browser.");
 		} finally {
 			setIsGeneratingKey(false);
+		}
+	};
+
+	const handleCopyPublicKey = async () => {
+		setCopyPublicKeyMessage(null);
+		if (!generatedPublicKey) {
+			setKeyGenerationError("Generate a key first to copy its public key.");
+			return;
+		}
+		try {
+			await navigator.clipboard.writeText(generatedPublicKey);
+			setCopyPublicKeyMessage("Public key copied to clipboard.");
+		} catch {
+			setKeyGenerationError("Could not copy public key to clipboard.");
 		}
 	};
 
@@ -119,17 +137,29 @@ export const SftpRepositoryForm = ({ form }: Props) => {
 						</FormControl>
 						<FormDescription>Paste the contents of your SSH private key.</FormDescription>
 						<FormMessage />
-						<Button
-							type="button"
-							variant="outline"
-							size="sm"
-							onClick={() => void handleGenerateKey()}
-							disabled={isGeneratingKey}
-						>
-							{isGeneratingKey ? "Generating..." : "Generate SSH Private Key"}
-						</Button>
+						<div className="flex flex-wrap gap-2">
+							<Button
+								type="button"
+								variant="outline"
+								size="sm"
+								onClick={() => void handleGenerateKey()}
+								disabled={isGeneratingKey}
+							>
+								{isGeneratingKey ? "Generating..." : "Generate SSH Key Pair"}
+							</Button>
+							<Button
+								type="button"
+								variant="outline"
+								size="sm"
+								onClick={() => void handleCopyPublicKey()}
+								disabled={isGeneratingKey || !generatedPublicKey}
+							>
+								Copy Public Key
+							</Button>
+						</div>
 						<FormDescription>The key is generated privately in your browser. Don't forget to save it!</FormDescription>
 						{keyGenerationError && <FormMessage className="text-xs text-destructive">{keyGenerationError}</FormMessage>}
+						{copyPublicKeyMessage && <FormMessage className="text-xs text-success">{copyPublicKeyMessage}</FormMessage>}
 					</FormItem>
 				)}
 			/>

--- a/app/client/modules/volumes/components/volume-forms/sftp-form.tsx
+++ b/app/client/modules/volumes/components/volume-forms/sftp-form.tsx
@@ -14,42 +14,10 @@ import { SecretInput } from "../../../../components/ui/secret-input";
 import { Textarea } from "../../../../components/ui/textarea";
 import { Switch } from "../../../../components/ui/switch";
 import { Button } from "~/client/components/ui/button";
+import { generatePrivateKeyPem } from "~/utils/ssh";
 
 type Props = {
 	form: UseFormReturn<FormValues>;
-};
-
-const arrayBufferToBase64 = (buffer: ArrayBuffer) => {
-	let binary = "";
-	const bytes = new Uint8Array(buffer);
-	const chunkSize = 0x8000;
-
-	for (let i = 0; i < bytes.length; i += chunkSize) {
-		binary += String.fromCharCode(...bytes.subarray(i, i + chunkSize));
-	}
-
-	return btoa(binary);
-};
-
-const toPem = (base64: string, label: string) => {
-	const wrapped = base64.match(/.{1,64}/g)?.join("\n") ?? base64;
-	return `-----BEGIN ${label}-----\n${wrapped}\n-----END ${label}-----`;
-};
-
-const generatePrivateKeyPem = async () => {
-	const keyPair = await crypto.subtle.generateKey(
-		{
-			name: "RSASSA-PKCS1-v1_5",
-			modulusLength: 4096,
-			publicExponent: new Uint8Array([1, 0, 1]),
-			hash: "SHA-256",
-		},
-		true,
-		["sign", "verify"],
-	);
-
-	const privateKey = await crypto.subtle.exportKey("pkcs8", keyPair.privateKey);
-	return toPem(arrayBufferToBase64(privateKey), "OPENSSH PRIVATE KEY");
 };
 
 export const SFTPForm = ({ form }: Props) => {

--- a/app/client/modules/volumes/components/volume-forms/sftp-form.tsx
+++ b/app/client/modules/volumes/components/volume-forms/sftp-form.tsx
@@ -14,7 +14,7 @@ import { SecretInput } from "../../../../components/ui/secret-input";
 import { Textarea } from "../../../../components/ui/textarea";
 import { Switch } from "../../../../components/ui/switch";
 import { Button } from "~/client/components/ui/button";
-import { generatePrivateKeyPem } from "~/utils/ssh";
+import { generateSshKeyPairPem } from "~/utils/ssh";
 
 type Props = {
 	form: UseFormReturn<FormValues>;
@@ -24,22 +24,40 @@ export const SFTPForm = ({ form }: Props) => {
 	const skipHostKeyCheck = useWatch({ control: form.control, name: "skipHostKeyCheck" });
 	const [isGeneratingKey, setIsGeneratingKey] = useState(false);
 	const [keyGenerationError, setKeyGenerationError] = useState<string | null>(null);
+	const [generatedPublicKey, setGeneratedPublicKey] = useState<string | null>(null);
+	const [copyPublicKeyMessage, setCopyPublicKeyMessage] = useState<string | null>(null);
 
 	const handleGenerateKey = async () => {
 		setIsGeneratingKey(true);
 		setKeyGenerationError(null);
 
 		try {
-			const privateKey = await generatePrivateKeyPem();
-			form.setValue("privateKey", privateKey, {
+			const { privateKeyPem, publicKeyPem } = await generateSshKeyPairPem();
+			form.setValue("privateKey", privateKeyPem, {
 				shouldDirty: true,
 				shouldTouch: true,
 				shouldValidate: true,
 			});
+			setGeneratedPublicKey(publicKeyPem);
 		} catch {
+			setGeneratedPublicKey(null);
 			setKeyGenerationError("Could not generate SSH key in this browser.");
 		} finally {
 			setIsGeneratingKey(false);
+		}
+	};
+
+	const handleCopyPublicKey = async () => {
+		setCopyPublicKeyMessage(null);
+		if (!generatedPublicKey) {
+			setKeyGenerationError("Generate a key first to copy its public key.");
+			return;
+		}
+		try {
+			await navigator.clipboard.writeText(generatedPublicKey);
+			setCopyPublicKeyMessage("Public key copied to clipboard.");
+		} catch {
+			setKeyGenerationError("Could not copy public key to clipboard.");
 		}
 	};
 
@@ -123,17 +141,29 @@ export const SFTPForm = ({ form }: Props) => {
 						</FormControl>
 						<FormDescription>SSH private key for authentication (optional if using password).</FormDescription>
 						<FormMessage />
-						<Button
-							type="button"
-							variant="outline"
-							size="sm"
-							onClick={() => void handleGenerateKey()}
-							disabled={isGeneratingKey}
-						>
-							{isGeneratingKey ? "Generating..." : "Generate SSH Private Key"}
-						</Button>
+						<div className="flex flex-wrap gap-2">
+							<Button
+								type="button"
+								variant="outline"
+								size="sm"
+								onClick={() => void handleGenerateKey()}
+								disabled={isGeneratingKey}
+							>
+								{isGeneratingKey ? "Generating..." : "Generate SSH Key Pair"}
+							</Button>
+							<Button
+								type="button"
+								variant="outline"
+								size="sm"
+								onClick={() => void handleCopyPublicKey()}
+								disabled={isGeneratingKey || !generatedPublicKey}
+							>
+								Copy Public Key
+							</Button>
+						</div>
 						<FormDescription>The key is generated privately in your browser. Don't forget to save it!</FormDescription>
 						{keyGenerationError && <FormMessage className="text-xs text-destructive">{keyGenerationError}</FormMessage>}
+						{copyPublicKeyMessage && <FormMessage className="text-xs text-success">{copyPublicKeyMessage}</FormMessage>}
 					</FormItem>
 				)}
 			/>

--- a/app/client/modules/volumes/components/volume-forms/sftp-form.tsx
+++ b/app/client/modules/volumes/components/volume-forms/sftp-form.tsx
@@ -1,4 +1,5 @@
 import { useWatch, type UseFormReturn } from "react-hook-form";
+import { useState } from "react";
 import type { FormValues } from "../create-volume-form";
 import {
 	FormControl,
@@ -12,13 +13,67 @@ import { Input } from "../../../../components/ui/input";
 import { SecretInput } from "../../../../components/ui/secret-input";
 import { Textarea } from "../../../../components/ui/textarea";
 import { Switch } from "../../../../components/ui/switch";
+import { Button } from "~/client/components/ui/button";
 
 type Props = {
 	form: UseFormReturn<FormValues>;
 };
 
+const arrayBufferToBase64 = (buffer: ArrayBuffer) => {
+	let binary = "";
+	const bytes = new Uint8Array(buffer);
+	const chunkSize = 0x8000;
+
+	for (let i = 0; i < bytes.length; i += chunkSize) {
+		binary += String.fromCharCode(...bytes.subarray(i, i + chunkSize));
+	}
+
+	return btoa(binary);
+};
+
+const toPem = (base64: string, label: string) => {
+	const wrapped = base64.match(/.{1,64}/g)?.join("\n") ?? base64;
+	return `-----BEGIN ${label}-----\n${wrapped}\n-----END ${label}-----`;
+};
+
+const generatePrivateKeyPem = async () => {
+	const keyPair = await crypto.subtle.generateKey(
+		{
+			name: "RSASSA-PKCS1-v1_5",
+			modulusLength: 4096,
+			publicExponent: new Uint8Array([1, 0, 1]),
+			hash: "SHA-256",
+		},
+		true,
+		["sign", "verify"],
+	);
+
+	const privateKey = await crypto.subtle.exportKey("pkcs8", keyPair.privateKey);
+	return toPem(arrayBufferToBase64(privateKey), "OPENSSH PRIVATE KEY");
+};
+
 export const SFTPForm = ({ form }: Props) => {
 	const skipHostKeyCheck = useWatch({ control: form.control, name: "skipHostKeyCheck" });
+	const [isGeneratingKey, setIsGeneratingKey] = useState(false);
+	const [keyGenerationError, setKeyGenerationError] = useState<string | null>(null);
+
+	const handleGenerateKey = async () => {
+		setIsGeneratingKey(true);
+		setKeyGenerationError(null);
+
+		try {
+			const privateKey = await generatePrivateKeyPem();
+			form.setValue("privateKey", privateKey, {
+				shouldDirty: true,
+				shouldTouch: true,
+				shouldValidate: true,
+			});
+		} catch {
+			setKeyGenerationError("Could not generate SSH key in this browser.");
+		} finally {
+			setIsGeneratingKey(false);
+		}
+	};
 
 	return (
 		<>
@@ -100,6 +155,17 @@ export const SFTPForm = ({ form }: Props) => {
 						</FormControl>
 						<FormDescription>SSH private key for authentication (optional if using password).</FormDescription>
 						<FormMessage />
+						<Button
+							type="button"
+							variant="outline"
+							size="sm"
+							onClick={() => void handleGenerateKey()}
+							disabled={isGeneratingKey}
+						>
+							{isGeneratingKey ? "Generating..." : "Generate SSH Private Key"}
+						</Button>
+						<FormDescription>The key is generated privately in your browser. Don't forget to save it!</FormDescription>
+						{keyGenerationError && <FormMessage className="text-xs text-destructive">{keyGenerationError}</FormMessage>}
 					</FormItem>
 				)}
 			/>

--- a/app/utils/ssh.ts
+++ b/app/utils/ssh.ts
@@ -1,0 +1,32 @@
+const arrayBufferToBase64 = (buffer: ArrayBuffer) => {
+	let binary = "";
+	const bytes = new Uint8Array(buffer);
+	const chunkSize = 0x8000;
+
+	for (let i = 0; i < bytes.length; i += chunkSize) {
+		binary += String.fromCharCode(...bytes.subarray(i, i + chunkSize));
+	}
+
+	return btoa(binary);
+};
+
+const toPem = (base64: string, label: string) => {
+	const wrapped = base64.match(/.{1,64}/g)?.join("\n") ?? base64;
+	return `-----BEGIN ${label}-----\n${wrapped}\n-----END ${label}-----`;
+};
+
+export const generatePrivateKeyPem = async () => {
+	const keyPair = await crypto.subtle.generateKey(
+		{
+			name: "RSASSA-PKCS1-v1_5",
+			modulusLength: 4096,
+			publicExponent: new Uint8Array([1, 0, 1]),
+			hash: "SHA-256",
+		},
+		true,
+		["sign", "verify"],
+	);
+
+	const privateKey = await crypto.subtle.exportKey("pkcs8", keyPair.privateKey);
+	return toPem(arrayBufferToBase64(privateKey), "OPENSSH PRIVATE KEY");
+};

--- a/app/utils/ssh.ts
+++ b/app/utils/ssh.ts
@@ -15,7 +15,7 @@ const toPem = (base64: string, label: string) => {
 	return `-----BEGIN ${label}-----\n${wrapped}\n-----END ${label}-----`;
 };
 
-export const generatePrivateKeyPem = async () => {
+export const generateSshKeyPairPem = async () => {
 	const keyPair = await crypto.subtle.generateKey(
 		{
 			name: "RSASSA-PKCS1-v1_5",
@@ -28,5 +28,15 @@ export const generatePrivateKeyPem = async () => {
 	);
 
 	const privateKey = await crypto.subtle.exportKey("pkcs8", keyPair.privateKey);
-	return toPem(arrayBufferToBase64(privateKey), "OPENSSH PRIVATE KEY");
+	const publicKey = await crypto.subtle.exportKey("spki", keyPair.publicKey);
+
+	return {
+		privateKeyPem: toPem(arrayBufferToBase64(privateKey), "PRIVATE KEY"),
+		publicKeyPem: toPem(arrayBufferToBase64(publicKey), "PUBLIC KEY"),
+	};
+};
+
+export const generatePrivateKeyPem = async () => {
+	const keyPair = await generateSshKeyPairPem();
+	return keyPair.privateKeyPem;
 };


### PR DESCRIPTION
Proposition to solve #589 issue by adding ssh key generation buttons on sftp volume & repository creation pages.
- Adds a new ssh utils file with the keypair generation function
- The key is generated in browser and auto-fills the form fill
- Adds a Copy public key button that enables after keypair generation
- Nice little description message and error message if it fails