### PR TITLE
fix(2fa): add missing 2fa column

### DIFF
--- a/app/drizzle/20260522174225_organic_nehzno/migration.sql
+++ b/app/drizzle/20260522174225_organic_nehzno/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `two_factor` ADD `verified` integer DEFAULT true NOT NULL;

--- a/app/drizzle/20260522174225_organic_nehzno/snapshot.json
+++ b/app/drizzle/20260522174225_organic_nehzno/snapshot.json
@@ -1,0 +1,2821 @@
+{
+	"version": "7",
+	"dialect": "sqlite",
+	"id": "696c496b-8cb7-47eb-8845-5b7a62ca9220",
+	"prevIds": ["b069bbe8-f836-4022-9090-362de4c99af9"],
+	"ddl": [
+		{
+			"name": "account",
+			"entityType": "tables"
+		},
+		{
+			"name": "agents_table",
+			"entityType": "tables"
+		},
+		{
+			"name": "app_metadata",
+			"entityType": "tables"
+		},
+		{
+			"name": "backup_schedule_mirrors_table",
+			"entityType": "tables"
+		},
+		{
+			"name": "backup_schedule_notifications_table",
+			"entityType": "tables"
+		},
+		{
+			"name": "backup_schedules_table",
+			"entityType": "tables"
+		},
+		{
+			"name": "invitation",
+			"entityType": "tables"
+		},
+		{
+			"name": "member",
+			"entityType": "tables"
+		},
+		{
+			"name": "notification_destinations_table",
+			"entityType": "tables"
+		},
+		{
+			"name": "organization",
+			"entityType": "tables"
+		},
+		{
+			"name": "repositories_table",
+			"entityType": "tables"
+		},
+		{
+			"name": "repository_lock_waiters",
+			"entityType": "tables"
+		},
+		{
+			"name": "repository_locks",
+			"entityType": "tables"
+		},
+		{
+			"name": "sessions_table",
+			"entityType": "tables"
+		},
+		{
+			"name": "sso_provider",
+			"entityType": "tables"
+		},
+		{
+			"name": "two_factor",
+			"entityType": "tables"
+		},
+		{
+			"name": "users_table",
+			"entityType": "tables"
+		},
+		{
+			"name": "verification",
+			"entityType": "tables"
+		},
+		{
+			"name": "volumes_table",
+			"entityType": "tables"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "id",
+			"entityType": "columns",
+			"table": "account"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "account_id",
+			"entityType": "columns",
+			"table": "account"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "provider_id",
+			"entityType": "columns",
+			"table": "account"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "user_id",
+			"entityType": "columns",
+			"table": "account"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "access_token",
+			"entityType": "columns",
+			"table": "account"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "refresh_token",
+			"entityType": "columns",
+			"table": "account"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "id_token",
+			"entityType": "columns",
+			"table": "account"
+		},
+		{
+			"type": "integer",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "access_token_expires_at",
+			"entityType": "columns",
+			"table": "account"
+		},
+		{
+			"type": "integer",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "refresh_token_expires_at",
+			"entityType": "columns",
+			"table": "account"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "scope",
+			"entityType": "columns",
+			"table": "account"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "password",
+			"entityType": "columns",
+			"table": "account"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch() * 1000)",
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "account"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch() * 1000)",
+			"generated": null,
+			"name": "updated_at",
+			"entityType": "columns",
+			"table": "account"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "id",
+			"entityType": "columns",
+			"table": "agents_table"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "organization_id",
+			"entityType": "columns",
+			"table": "agents_table"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "name",
+			"entityType": "columns",
+			"table": "agents_table"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "kind",
+			"entityType": "columns",
+			"table": "agents_table"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "'offline'",
+			"generated": null,
+			"name": "status",
+			"entityType": "columns",
+			"table": "agents_table"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "'{}'",
+			"generated": null,
+			"name": "capabilities",
+			"entityType": "columns",
+			"table": "agents_table"
+		},
+		{
+			"type": "integer",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "last_seen_at",
+			"entityType": "columns",
+			"table": "agents_table"
+		},
+		{
+			"type": "integer",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "last_ready_at",
+			"entityType": "columns",
+			"table": "agents_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch() * 1000)",
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "agents_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch() * 1000)",
+			"generated": null,
+			"name": "updated_at",
+			"entityType": "columns",
+			"table": "agents_table"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "key",
+			"entityType": "columns",
+			"table": "app_metadata"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "value",
+			"entityType": "columns",
+			"table": "app_metadata"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch() * 1000)",
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "app_metadata"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch() * 1000)",
+			"generated": null,
+			"name": "updated_at",
+			"entityType": "columns",
+			"table": "app_metadata"
+		},
+		{
+			"type": "integer",
+			"notNull": false,
+			"autoincrement": true,
+			"default": null,
+			"generated": null,
+			"name": "id",
+			"entityType": "columns",
+			"table": "backup_schedule_mirrors_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "schedule_id",
+			"entityType": "columns",
+			"table": "backup_schedule_mirrors_table"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "repository_id",
+			"entityType": "columns",
+			"table": "backup_schedule_mirrors_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "true",
+			"generated": null,
+			"name": "enabled",
+			"entityType": "columns",
+			"table": "backup_schedule_mirrors_table"
+		},
+		{
+			"type": "integer",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "last_copy_at",
+			"entityType": "columns",
+			"table": "backup_schedule_mirrors_table"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "last_copy_status",
+			"entityType": "columns",
+			"table": "backup_schedule_mirrors_table"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "last_copy_error",
+			"entityType": "columns",
+			"table": "backup_schedule_mirrors_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch() * 1000)",
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "backup_schedule_mirrors_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "schedule_id",
+			"entityType": "columns",
+			"table": "backup_schedule_notifications_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "destination_id",
+			"entityType": "columns",
+			"table": "backup_schedule_notifications_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "false",
+			"generated": null,
+			"name": "notify_on_start",
+			"entityType": "columns",
+			"table": "backup_schedule_notifications_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "false",
+			"generated": null,
+			"name": "notify_on_success",
+			"entityType": "columns",
+			"table": "backup_schedule_notifications_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "true",
+			"generated": null,
+			"name": "notify_on_warning",
+			"entityType": "columns",
+			"table": "backup_schedule_notifications_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "true",
+			"generated": null,
+			"name": "notify_on_failure",
+			"entityType": "columns",
+			"table": "backup_schedule_notifications_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch() * 1000)",
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "backup_schedule_notifications_table"
+		},
+		{
+			"type": "integer",
+			"notNull": false,
+			"autoincrement": true,
+			"default": null,
+			"generated": null,
+			"name": "id",
+			"entityType": "columns",
+			"table": "backup_schedules_table"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "short_id",
+			"entityType": "columns",
+			"table": "backup_schedules_table"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "name",
+			"entityType": "columns",
+			"table": "backup_schedules_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "volume_id",
+			"entityType": "columns",
+			"table": "backup_schedules_table"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "repository_id",
+			"entityType": "columns",
+			"table": "backup_schedules_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "true",
+			"generated": null,
+			"name": "enabled",
+			"entityType": "columns",
+			"table": "backup_schedules_table"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "cron_expression",
+			"entityType": "columns",
+			"table": "backup_schedules_table"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "retention_policy",
+			"entityType": "columns",
+			"table": "backup_schedules_table"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": "'[]'",
+			"generated": null,
+			"name": "exclude_patterns",
+			"entityType": "columns",
+			"table": "backup_schedules_table"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": "'[]'",
+			"generated": null,
+			"name": "exclude_if_present",
+			"entityType": "columns",
+			"table": "backup_schedules_table"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": "'[]'",
+			"generated": null,
+			"name": "include_paths",
+			"entityType": "columns",
+			"table": "backup_schedules_table"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": "'[]'",
+			"generated": null,
+			"name": "include_patterns",
+			"entityType": "columns",
+			"table": "backup_schedules_table"
+		},
+		{
+			"type": "integer",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "last_backup_at",
+			"entityType": "columns",
+			"table": "backup_schedules_table"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "last_backup_status",
+			"entityType": "columns",
+			"table": "backup_schedules_table"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "last_backup_error",
+			"entityType": "columns",
+			"table": "backup_schedules_table"
+		},
+		{
+			"type": "integer",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "next_backup_at",
+			"entityType": "columns",
+			"table": "backup_schedules_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "false",
+			"generated": null,
+			"name": "one_file_system",
+			"entityType": "columns",
+			"table": "backup_schedules_table"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": "'[]'",
+			"generated": null,
+			"name": "custom_restic_params",
+			"entityType": "columns",
+			"table": "backup_schedules_table"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "backup_webhooks",
+			"entityType": "columns",
+			"table": "backup_schedules_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "0",
+			"generated": null,
+			"name": "sort_order",
+			"entityType": "columns",
+			"table": "backup_schedules_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "0",
+			"generated": null,
+			"name": "failure_retry_count",
+			"entityType": "columns",
+			"table": "backup_schedules_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "2",
+			"generated": null,
+			"name": "max_retries",
+			"entityType": "columns",
+			"table": "backup_schedules_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "900000",
+			"generated": null,
+			"name": "retry_delay",
+			"entityType": "columns",
+			"table": "backup_schedules_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch() * 1000)",
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "backup_schedules_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch() * 1000)",
+			"generated": null,
+			"name": "updated_at",
+			"entityType": "columns",
+			"table": "backup_schedules_table"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "organization_id",
+			"entityType": "columns",
+			"table": "backup_schedules_table"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "id",
+			"entityType": "columns",
+			"table": "invitation"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "organization_id",
+			"entityType": "columns",
+			"table": "invitation"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "email",
+			"entityType": "columns",
+			"table": "invitation"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "role",
+			"entityType": "columns",
+			"table": "invitation"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "'pending'",
+			"generated": null,
+			"name": "status",
+			"entityType": "columns",
+			"table": "invitation"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "expires_at",
+			"entityType": "columns",
+			"table": "invitation"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "invitation"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "inviter_id",
+			"entityType": "columns",
+			"table": "invitation"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "id",
+			"entityType": "columns",
+			"table": "member"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "organization_id",
+			"entityType": "columns",
+			"table": "member"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "user_id",
+			"entityType": "columns",
+			"table": "member"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "'member'",
+			"generated": null,
+			"name": "role",
+			"entityType": "columns",
+			"table": "member"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "member"
+		},
+		{
+			"type": "integer",
+			"notNull": false,
+			"autoincrement": true,
+			"default": null,
+			"generated": null,
+			"name": "id",
+			"entityType": "columns",
+			"table": "notification_destinations_table"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "name",
+			"entityType": "columns",
+			"table": "notification_destinations_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "true",
+			"generated": null,
+			"name": "enabled",
+			"entityType": "columns",
+			"table": "notification_destinations_table"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "'unknown'",
+			"generated": null,
+			"name": "status",
+			"entityType": "columns",
+			"table": "notification_destinations_table"
+		},
+		{
+			"type": "integer",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "last_checked",
+			"entityType": "columns",
+			"table": "notification_destinations_table"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "last_error",
+			"entityType": "columns",
+			"table": "notification_destinations_table"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "type",
+			"entityType": "columns",
+			"table": "notification_destinations_table"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "config",
+			"entityType": "columns",
+			"table": "notification_destinations_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch() * 1000)",
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "notification_destinations_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch() * 1000)",
+			"generated": null,
+			"name": "updated_at",
+			"entityType": "columns",
+			"table": "notification_destinations_table"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "organization_id",
+			"entityType": "columns",
+			"table": "notification_destinations_table"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "id",
+			"entityType": "columns",
+			"table": "organization"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "name",
+			"entityType": "columns",
+			"table": "organization"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "slug",
+			"entityType": "columns",
+			"table": "organization"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "logo",
+			"entityType": "columns",
+			"table": "organization"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "organization"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "metadata",
+			"entityType": "columns",
+			"table": "organization"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "id",
+			"entityType": "columns",
+			"table": "repositories_table"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "short_id",
+			"entityType": "columns",
+			"table": "repositories_table"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "provisioning_id",
+			"entityType": "columns",
+			"table": "repositories_table"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "name",
+			"entityType": "columns",
+			"table": "repositories_table"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "type",
+			"entityType": "columns",
+			"table": "repositories_table"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "config",
+			"entityType": "columns",
+			"table": "repositories_table"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": "'auto'",
+			"generated": null,
+			"name": "compression_mode",
+			"entityType": "columns",
+			"table": "repositories_table"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": "'unknown'",
+			"generated": null,
+			"name": "status",
+			"entityType": "columns",
+			"table": "repositories_table"
+		},
+		{
+			"type": "integer",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "last_checked",
+			"entityType": "columns",
+			"table": "repositories_table"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "last_error",
+			"entityType": "columns",
+			"table": "repositories_table"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "doctor_result",
+			"entityType": "columns",
+			"table": "repositories_table"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "stats",
+			"entityType": "columns",
+			"table": "repositories_table"
+		},
+		{
+			"type": "integer",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "stats_updated_at",
+			"entityType": "columns",
+			"table": "repositories_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "false",
+			"generated": null,
+			"name": "upload_limit_enabled",
+			"entityType": "columns",
+			"table": "repositories_table"
+		},
+		{
+			"type": "real",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "1",
+			"generated": null,
+			"name": "upload_limit_value",
+			"entityType": "columns",
+			"table": "repositories_table"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "'Mbps'",
+			"generated": null,
+			"name": "upload_limit_unit",
+			"entityType": "columns",
+			"table": "repositories_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "false",
+			"generated": null,
+			"name": "download_limit_enabled",
+			"entityType": "columns",
+			"table": "repositories_table"
+		},
+		{
+			"type": "real",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "1",
+			"generated": null,
+			"name": "download_limit_value",
+			"entityType": "columns",
+			"table": "repositories_table"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "'Mbps'",
+			"generated": null,
+			"name": "download_limit_unit",
+			"entityType": "columns",
+			"table": "repositories_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch() * 1000)",
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "repositories_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch() * 1000)",
+			"generated": null,
+			"name": "updated_at",
+			"entityType": "columns",
+			"table": "repositories_table"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "organization_id",
+			"entityType": "columns",
+			"table": "repositories_table"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "id",
+			"entityType": "columns",
+			"table": "repository_lock_waiters"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "repository_id",
+			"entityType": "columns",
+			"table": "repository_lock_waiters"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "type",
+			"entityType": "columns",
+			"table": "repository_lock_waiters"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "operation",
+			"entityType": "columns",
+			"table": "repository_lock_waiters"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "owner_id",
+			"entityType": "columns",
+			"table": "repository_lock_waiters"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "requested_at",
+			"entityType": "columns",
+			"table": "repository_lock_waiters"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "expires_at",
+			"entityType": "columns",
+			"table": "repository_lock_waiters"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "heartbeat_at",
+			"entityType": "columns",
+			"table": "repository_lock_waiters"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "id",
+			"entityType": "columns",
+			"table": "repository_locks"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "repository_id",
+			"entityType": "columns",
+			"table": "repository_locks"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "type",
+			"entityType": "columns",
+			"table": "repository_locks"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "operation",
+			"entityType": "columns",
+			"table": "repository_locks"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "owner_id",
+			"entityType": "columns",
+			"table": "repository_locks"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "acquired_at",
+			"entityType": "columns",
+			"table": "repository_locks"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "expires_at",
+			"entityType": "columns",
+			"table": "repository_locks"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "heartbeat_at",
+			"entityType": "columns",
+			"table": "repository_locks"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "id",
+			"entityType": "columns",
+			"table": "sessions_table"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "user_id",
+			"entityType": "columns",
+			"table": "sessions_table"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "token",
+			"entityType": "columns",
+			"table": "sessions_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "expires_at",
+			"entityType": "columns",
+			"table": "sessions_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch() * 1000)",
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "sessions_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch() * 1000)",
+			"generated": null,
+			"name": "updated_at",
+			"entityType": "columns",
+			"table": "sessions_table"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "ip_address",
+			"entityType": "columns",
+			"table": "sessions_table"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "user_agent",
+			"entityType": "columns",
+			"table": "sessions_table"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "impersonated_by",
+			"entityType": "columns",
+			"table": "sessions_table"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "active_organization_id",
+			"entityType": "columns",
+			"table": "sessions_table"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "id",
+			"entityType": "columns",
+			"table": "sso_provider"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "provider_id",
+			"entityType": "columns",
+			"table": "sso_provider"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "organization_id",
+			"entityType": "columns",
+			"table": "sso_provider"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "user_id",
+			"entityType": "columns",
+			"table": "sso_provider"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "issuer",
+			"entityType": "columns",
+			"table": "sso_provider"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "domain",
+			"entityType": "columns",
+			"table": "sso_provider"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "false",
+			"generated": null,
+			"name": "auto_link_matching_emails",
+			"entityType": "columns",
+			"table": "sso_provider"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "oidc_config",
+			"entityType": "columns",
+			"table": "sso_provider"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "saml_config",
+			"entityType": "columns",
+			"table": "sso_provider"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch() * 1000)",
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "sso_provider"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch() * 1000)",
+			"generated": null,
+			"name": "updated_at",
+			"entityType": "columns",
+			"table": "sso_provider"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "id",
+			"entityType": "columns",
+			"table": "two_factor"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "secret",
+			"entityType": "columns",
+			"table": "two_factor"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "backup_codes",
+			"entityType": "columns",
+			"table": "two_factor"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "user_id",
+			"entityType": "columns",
+			"table": "two_factor"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "true",
+			"generated": null,
+			"name": "verified",
+			"entityType": "columns",
+			"table": "two_factor"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "id",
+			"entityType": "columns",
+			"table": "users_table"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "username",
+			"entityType": "columns",
+			"table": "users_table"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "password_hash",
+			"entityType": "columns",
+			"table": "users_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "false",
+			"generated": null,
+			"name": "has_downloaded_restic_password",
+			"entityType": "columns",
+			"table": "users_table"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "'MM/DD/YYYY'",
+			"generated": null,
+			"name": "date_format",
+			"entityType": "columns",
+			"table": "users_table"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "'12h'",
+			"generated": null,
+			"name": "time_format",
+			"entityType": "columns",
+			"table": "users_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch() * 1000)",
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "users_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch() * 1000)",
+			"generated": null,
+			"name": "updated_at",
+			"entityType": "columns",
+			"table": "users_table"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "name",
+			"entityType": "columns",
+			"table": "users_table"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "email",
+			"entityType": "columns",
+			"table": "users_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "false",
+			"generated": null,
+			"name": "email_verified",
+			"entityType": "columns",
+			"table": "users_table"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "image",
+			"entityType": "columns",
+			"table": "users_table"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "display_username",
+			"entityType": "columns",
+			"table": "users_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "false",
+			"generated": null,
+			"name": "two_factor_enabled",
+			"entityType": "columns",
+			"table": "users_table"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "'user'",
+			"generated": null,
+			"name": "role",
+			"entityType": "columns",
+			"table": "users_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "false",
+			"generated": null,
+			"name": "banned",
+			"entityType": "columns",
+			"table": "users_table"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "ban_reason",
+			"entityType": "columns",
+			"table": "users_table"
+		},
+		{
+			"type": "integer",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "ban_expires",
+			"entityType": "columns",
+			"table": "users_table"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "id",
+			"entityType": "columns",
+			"table": "verification"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "identifier",
+			"entityType": "columns",
+			"table": "verification"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "value",
+			"entityType": "columns",
+			"table": "verification"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "expires_at",
+			"entityType": "columns",
+			"table": "verification"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch() * 1000)",
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "verification"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch() * 1000)",
+			"generated": null,
+			"name": "updated_at",
+			"entityType": "columns",
+			"table": "verification"
+		},
+		{
+			"type": "integer",
+			"notNull": false,
+			"autoincrement": true,
+			"default": null,
+			"generated": null,
+			"name": "id",
+			"entityType": "columns",
+			"table": "volumes_table"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "short_id",
+			"entityType": "columns",
+			"table": "volumes_table"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "provisioning_id",
+			"entityType": "columns",
+			"table": "volumes_table"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "name",
+			"entityType": "columns",
+			"table": "volumes_table"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "type",
+			"entityType": "columns",
+			"table": "volumes_table"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "'unmounted'",
+			"generated": null,
+			"name": "status",
+			"entityType": "columns",
+			"table": "volumes_table"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "last_error",
+			"entityType": "columns",
+			"table": "volumes_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch() * 1000)",
+			"generated": null,
+			"name": "last_health_check",
+			"entityType": "columns",
+			"table": "volumes_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch() * 1000)",
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "volumes_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch() * 1000)",
+			"generated": null,
+			"name": "updated_at",
+			"entityType": "columns",
+			"table": "volumes_table"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "config",
+			"entityType": "columns",
+			"table": "volumes_table"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "true",
+			"generated": null,
+			"name": "auto_remount",
+			"entityType": "columns",
+			"table": "volumes_table"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "'local'",
+			"generated": null,
+			"name": "agent_id",
+			"entityType": "columns",
+			"table": "volumes_table"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "organization_id",
+			"entityType": "columns",
+			"table": "volumes_table"
+		},
+		{
+			"columns": ["user_id"],
+			"tableTo": "users_table",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "CASCADE",
+			"nameExplicit": false,
+			"name": "account_user_id_users_table_id_fk",
+			"entityType": "fks",
+			"table": "account"
+		},
+		{
+			"columns": ["organization_id"],
+			"tableTo": "organization",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "CASCADE",
+			"nameExplicit": false,
+			"name": "fk_agents_table_organization_id_organization_id_fk",
+			"entityType": "fks",
+			"table": "agents_table"
+		},
+		{
+			"columns": ["schedule_id"],
+			"tableTo": "backup_schedules_table",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "CASCADE",
+			"nameExplicit": false,
+			"name": "backup_schedule_mirrors_table_schedule_id_backup_schedules_table_id_fk",
+			"entityType": "fks",
+			"table": "backup_schedule_mirrors_table"
+		},
+		{
+			"columns": ["repository_id"],
+			"tableTo": "repositories_table",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "CASCADE",
+			"nameExplicit": false,
+			"name": "backup_schedule_mirrors_table_repository_id_repositories_table_id_fk",
+			"entityType": "fks",
+			"table": "backup_schedule_mirrors_table"
+		},
+		{
+			"columns": ["schedule_id"],
+			"tableTo": "backup_schedules_table",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "CASCADE",
+			"nameExplicit": false,
+			"name": "backup_schedule_notifications_table_schedule_id_backup_schedules_table_id_fk",
+			"entityType": "fks",
+			"table": "backup_schedule_notifications_table"
+		},
+		{
+			"columns": ["destination_id"],
+			"tableTo": "notification_destinations_table",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "CASCADE",
+			"nameExplicit": false,
+			"name": "backup_schedule_notifications_table_destination_id_notification_destinations_table_id_fk",
+			"entityType": "fks",
+			"table": "backup_schedule_notifications_table"
+		},
+		{
+			"columns": ["volume_id"],
+			"tableTo": "volumes_table",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "CASCADE",
+			"nameExplicit": false,
+			"name": "backup_schedules_table_volume_id_volumes_table_id_fk",
+			"entityType": "fks",
+			"table": "backup_schedules_table"
+		},
+		{
+			"columns": ["repository_id"],
+			"tableTo": "repositories_table",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "CASCADE",
+			"nameExplicit": false,
+			"name": "backup_schedules_table_repository_id_repositories_table_id_fk",
+			"entityType": "fks",
+			"table": "backup_schedules_table"
+		},
+		{
+			"columns": ["organization_id"],
+			"tableTo": "organization",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "CASCADE",
+			"nameExplicit": false,
+			"name": "backup_schedules_table_organization_id_organization_id_fk",
+			"entityType": "fks",
+			"table": "backup_schedules_table"
+		},
+		{
+			"columns": ["organization_id"],
+			"tableTo": "organization",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "CASCADE",
+			"nameExplicit": false,
+			"name": "invitation_organization_id_organization_id_fk",
+			"entityType": "fks",
+			"table": "invitation"
+		},
+		{
+			"columns": ["inviter_id"],
+			"tableTo": "users_table",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "CASCADE",
+			"nameExplicit": false,
+			"name": "invitation_inviter_id_users_table_id_fk",
+			"entityType": "fks",
+			"table": "invitation"
+		},
+		{
+			"columns": ["organization_id"],
+			"tableTo": "organization",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "CASCADE",
+			"nameExplicit": false,
+			"name": "member_organization_id_organization_id_fk",
+			"entityType": "fks",
+			"table": "member"
+		},
+		{
+			"columns": ["user_id"],
+			"tableTo": "users_table",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "CASCADE",
+			"nameExplicit": false,
+			"name": "member_user_id_users_table_id_fk",
+			"entityType": "fks",
+			"table": "member"
+		},
+		{
+			"columns": ["organization_id"],
+			"tableTo": "organization",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "CASCADE",
+			"nameExplicit": false,
+			"name": "notification_destinations_table_organization_id_organization_id_fk",
+			"entityType": "fks",
+			"table": "notification_destinations_table"
+		},
+		{
+			"columns": ["organization_id"],
+			"tableTo": "organization",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "CASCADE",
+			"nameExplicit": false,
+			"name": "repositories_table_organization_id_organization_id_fk",
+			"entityType": "fks",
+			"table": "repositories_table"
+		},
+		{
+			"columns": ["user_id"],
+			"tableTo": "users_table",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "CASCADE",
+			"nameExplicit": false,
+			"name": "sessions_table_user_id_users_table_id_fk",
+			"entityType": "fks",
+			"table": "sessions_table"
+		},
+		{
+			"columns": ["organization_id"],
+			"tableTo": "organization",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "CASCADE",
+			"nameExplicit": false,
+			"name": "fk_sso_provider_organization_id_organization_id_fk",
+			"entityType": "fks",
+			"table": "sso_provider"
+		},
+		{
+			"columns": ["user_id"],
+			"tableTo": "users_table",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "SET NULL",
+			"nameExplicit": false,
+			"name": "fk_sso_provider_user_id_users_table_id_fk",
+			"entityType": "fks",
+			"table": "sso_provider"
+		},
+		{
+			"columns": ["user_id"],
+			"tableTo": "users_table",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "CASCADE",
+			"nameExplicit": false,
+			"name": "two_factor_user_id_users_table_id_fk",
+			"entityType": "fks",
+			"table": "two_factor"
+		},
+		{
+			"columns": ["organization_id"],
+			"tableTo": "organization",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "CASCADE",
+			"nameExplicit": false,
+			"name": "volumes_table_organization_id_organization_id_fk",
+			"entityType": "fks",
+			"table": "volumes_table"
+		},
+		{
+			"columns": ["schedule_id", "destination_id"],
+			"nameExplicit": false,
+			"name": "backup_schedule_notifications_table_schedule_id_destination_id_pk",
+			"entityType": "pks",
+			"table": "backup_schedule_notifications_table"
+		},
+		{
+			"columns": ["id"],
+			"nameExplicit": false,
+			"name": "account_pk",
+			"table": "account",
+			"entityType": "pks"
+		},
+		{
+			"columns": ["id"],
+			"nameExplicit": false,
+			"name": "agents_table_pk",
+			"table": "agents_table",
+			"entityType": "pks"
+		},
+		{
+			"columns": ["key"],
+			"nameExplicit": false,
+			"name": "app_metadata_pk",
+			"table": "app_metadata",
+			"entityType": "pks"
+		},
+		{
+			"columns": ["id"],
+			"nameExplicit": false,
+			"name": "backup_schedule_mirrors_table_pk",
+			"table": "backup_schedule_mirrors_table",
+			"entityType": "pks"
+		},
+		{
+			"columns": ["id"],
+			"nameExplicit": false,
+			"name": "backup_schedules_table_pk",
+			"table": "backup_schedules_table",
+			"entityType": "pks"
+		},
+		{
+			"columns": ["id"],
+			"nameExplicit": false,
+			"name": "invitation_pk",
+			"table": "invitation",
+			"entityType": "pks"
+		},
+		{
+			"columns": ["id"],
+			"nameExplicit": false,
+			"name": "member_pk",
+			"table": "member",
+			"entityType": "pks"
+		},
+		{
+			"columns": ["id"],
+			"nameExplicit": false,
+			"name": "notification_destinations_table_pk",
+			"table": "notification_destinations_table",
+			"entityType": "pks"
+		},
+		{
+			"columns": ["id"],
+			"nameExplicit": false,
+			"name": "organization_pk",
+			"table": "organization",
+			"entityType": "pks"
+		},
+		{
+			"columns": ["id"],
+			"nameExplicit": false,
+			"name": "repositories_table_pk",
+			"table": "repositories_table",
+			"entityType": "pks"
+		},
+		{
+			"columns": ["id"],
+			"nameExplicit": false,
+			"name": "repository_lock_waiters_pk",
+			"table": "repository_lock_waiters",
+			"entityType": "pks"
+		},
+		{
+			"columns": ["id"],
+			"nameExplicit": false,
+			"name": "repository_locks_pk",
+			"table": "repository_locks",
+			"entityType": "pks"
+		},
+		{
+			"columns": ["id"],
+			"nameExplicit": false,
+			"name": "sessions_table_pk",
+			"table": "sessions_table",
+			"entityType": "pks"
+		},
+		{
+			"columns": ["id"],
+			"nameExplicit": false,
+			"name": "sso_provider_pk",
+			"table": "sso_provider",
+			"entityType": "pks"
+		},
+		{
+			"columns": ["id"],
+			"nameExplicit": false,
+			"name": "two_factor_pk",
+			"table": "two_factor",
+			"entityType": "pks"
+		},
+		{
+			"columns": ["id"],
+			"nameExplicit": false,
+			"name": "users_table_pk",
+			"table": "users_table",
+			"entityType": "pks"
+		},
+		{
+			"columns": ["id"],
+			"nameExplicit": false,
+			"name": "verification_pk",
+			"table": "verification",
+			"entityType": "pks"
+		},
+		{
+			"columns": ["id"],
+			"nameExplicit": false,
+			"name": "volumes_table_pk",
+			"table": "volumes_table",
+			"entityType": "pks"
+		},
+		{
+			"columns": [
+				{
+					"value": "user_id",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": null,
+			"origin": "manual",
+			"name": "account_userId_idx",
+			"entityType": "indexes",
+			"table": "account"
+		},
+		{
+			"columns": [
+				{
+					"value": "organization_id",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": null,
+			"origin": "manual",
+			"name": "agents_table_organization_id_idx",
+			"entityType": "indexes",
+			"table": "agents_table"
+		},
+		{
+			"columns": [
+				{
+					"value": "status",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": null,
+			"origin": "manual",
+			"name": "agents_table_status_idx",
+			"entityType": "indexes",
+			"table": "agents_table"
+		},
+		{
+			"columns": [
+				{
+					"value": "organization_id",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": null,
+			"origin": "manual",
+			"name": "invitation_organizationId_idx",
+			"entityType": "indexes",
+			"table": "invitation"
+		},
+		{
+			"columns": [
+				{
+					"value": "email",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": null,
+			"origin": "manual",
+			"name": "invitation_email_idx",
+			"entityType": "indexes",
+			"table": "invitation"
+		},
+		{
+			"columns": [
+				{
+					"value": "organization_id",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": null,
+			"origin": "manual",
+			"name": "member_organizationId_idx",
+			"entityType": "indexes",
+			"table": "member"
+		},
+		{
+			"columns": [
+				{
+					"value": "user_id",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": null,
+			"origin": "manual",
+			"name": "member_userId_idx",
+			"entityType": "indexes",
+			"table": "member"
+		},
+		{
+			"columns": [
+				{
+					"value": "organization_id",
+					"isExpression": false
+				},
+				{
+					"value": "user_id",
+					"isExpression": false
+				}
+			],
+			"isUnique": true,
+			"where": null,
+			"origin": "manual",
+			"name": "member_org_user_uidx",
+			"entityType": "indexes",
+			"table": "member"
+		},
+		{
+			"columns": [
+				{
+					"value": "slug",
+					"isExpression": false
+				}
+			],
+			"isUnique": true,
+			"where": null,
+			"origin": "manual",
+			"name": "organization_slug_uidx",
+			"entityType": "indexes",
+			"table": "organization"
+		},
+		{
+			"columns": [
+				{
+					"value": "organization_id",
+					"isExpression": false
+				},
+				{
+					"value": "provisioning_id",
+					"isExpression": false
+				}
+			],
+			"isUnique": true,
+			"where": null,
+			"origin": "manual",
+			"name": "repositories_table_org_provisioning_id_uidx",
+			"entityType": "indexes",
+			"table": "repositories_table"
+		},
+		{
+			"columns": [
+				{
+					"value": "repository_id",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": null,
+			"origin": "manual",
+			"name": "repository_lock_waiters_repository_id_idx",
+			"entityType": "indexes",
+			"table": "repository_lock_waiters"
+		},
+		{
+			"columns": [
+				{
+					"value": "expires_at",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": null,
+			"origin": "manual",
+			"name": "repository_lock_waiters_expires_at_idx",
+			"entityType": "indexes",
+			"table": "repository_lock_waiters"
+		},
+		{
+			"columns": [
+				{
+					"value": "owner_id",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": null,
+			"origin": "manual",
+			"name": "repository_lock_waiters_owner_id_idx",
+			"entityType": "indexes",
+			"table": "repository_lock_waiters"
+		},
+		{
+			"columns": [
+				{
+					"value": "repository_id",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": null,
+			"origin": "manual",
+			"name": "repository_locks_repository_id_idx",
+			"entityType": "indexes",
+			"table": "repository_locks"
+		},
+		{
+			"columns": [
+				{
+					"value": "expires_at",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": null,
+			"origin": "manual",
+			"name": "repository_locks_expires_at_idx",
+			"entityType": "indexes",
+			"table": "repository_locks"
+		},
+		{
+			"columns": [
+				{
+					"value": "owner_id",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": null,
+			"origin": "manual",
+			"name": "repository_locks_owner_id_idx",
+			"entityType": "indexes",
+			"table": "repository_locks"
+		},
+		{
+			"columns": [
+				{
+					"value": "user_id",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": null,
+			"origin": "manual",
+			"name": "sessionsTable_userId_idx",
+			"entityType": "indexes",
+			"table": "sessions_table"
+		},
+		{
+			"columns": [
+				{
+					"value": "secret",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": null,
+			"origin": "manual",
+			"name": "twoFactor_secret_idx",
+			"entityType": "indexes",
+			"table": "two_factor"
+		},
+		{
+			"columns": [
+				{
+					"value": "user_id",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": null,
+			"origin": "manual",
+			"name": "twoFactor_userId_idx",
+			"entityType": "indexes",
+			"table": "two_factor"
+		},
+		{
+			"columns": [
+				{
+					"value": "identifier",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": null,
+			"origin": "manual",
+			"name": "verification_identifier_idx",
+			"entityType": "indexes",
+			"table": "verification"
+		},
+		{
+			"columns": [
+				{
+					"value": "agent_id",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": null,
+			"origin": "manual",
+			"name": "volumes_table_agent_id_idx",
+			"entityType": "indexes",
+			"table": "volumes_table"
+		},
+		{
+			"columns": [
+				{
+					"value": "organization_id",
+					"isExpression": false
+				},
+				{
+					"value": "provisioning_id",
+					"isExpression": false
+				}
+			],
+			"isUnique": true,
+			"where": null,
+			"origin": "manual",
+			"name": "volumes_table_org_provisioning_id_uidx",
+			"entityType": "indexes",
+			"table": "volumes_table"
+		},
+		{
+			"columns": ["schedule_id", "repository_id"],
+			"nameExplicit": false,
+			"name": "backup_schedule_mirrors_table_schedule_id_repository_id_unique",
+			"entityType": "uniques",
+			"table": "backup_schedule_mirrors_table"
+		},
+		{
+			"columns": ["name", "organization_id"],
+			"nameExplicit": false,
+			"name": "volumes_table_name_organization_id_unique",
+			"entityType": "uniques",
+			"table": "volumes_table"
+		},
+		{
+			"columns": ["short_id"],
+			"nameExplicit": false,
+			"name": "backup_schedules_table_short_id_unique",
+			"entityType": "uniques",
+			"table": "backup_schedules_table"
+		},
+		{
+			"columns": ["short_id"],
+			"nameExplicit": false,
+			"name": "repositories_table_short_id_unique",
+			"entityType": "uniques",
+			"table": "repositories_table"
+		},
+		{
+			"columns": ["token"],
+			"nameExplicit": false,
+			"name": "sessions_table_token_unique",
+			"entityType": "uniques",
+			"table": "sessions_table"
+		},
+		{
+			"columns": ["provider_id"],
+			"nameExplicit": false,
+			"name": "sso_provider_provider_id_unique",
+			"entityType": "uniques",
+			"table": "sso_provider"
+		},
+		{
+			"columns": ["username"],
+			"nameExplicit": false,
+			"name": "users_table_username_unique",
+			"entityType": "uniques",
+			"table": "users_table"
+		},
+		{
+			"columns": ["email"],
+			"nameExplicit": false,
+			"name": "users_table_email_unique",
+			"entityType": "uniques",
+			"table": "users_table"
+		},
+		{
+			"columns": ["short_id"],
+			"nameExplicit": false,
+			"name": "volumes_table_short_id_unique",
+			"entityType": "uniques",
+			"table": "volumes_table"
+		}
+	],
+	"renames": []
+}

--- a/app/server/db/schema.ts
+++ b/app/server/db/schema.ts
@@ -505,6 +505,7 @@ export const twoFactor = sqliteTable(
 		userId: text("user_id")
 			.notNull()
 			.references(() => usersTable.id, { onDelete: "cascade" }),
+		verified: integer("verified", { mode: "boolean" }).notNull().default(true),
 	},
 	(table) => [index("twoFactor_secret_idx").on(table.secret), index("twoFactor_userId_idx").on(table.userId)],
 );

--- a/bun.lock
+++ b/bun.lock
@@ -71,6 +71,7 @@
         "zod": "^4.4.3",
       },
       "devDependencies": {
+        "@better-auth/utils": "0.4.0",
         "@effect/language-service": "^0.86.1",
         "@faker-js/faker": "^10.4.0",
         "@hey-api/openapi-ts": "^0.97.1",

--- a/e2e/0005-two-factor.spec.ts
+++ b/e2e/0005-two-factor.spec.ts
@@ -1,0 +1,51 @@
+import type { Page } from "@playwright/test";
+import { base32 } from "@better-auth/utils/base32";
+import { createOTP } from "@better-auth/utils/otp";
+import { expect, test } from "./test";
+import { gotoAndWaitForAppReady } from "./helpers/page";
+
+const workerPassword = "password123";
+
+async function generateTotp(secret: string) {
+	const decodedSecret = new TextDecoder().decode(base32.decode(secret));
+	return createOTP(decodedSecret).totp();
+}
+
+async function fillOtp(page: Page, code: string) {
+	await page.locator('[data-slot="input-otp"]').click();
+	await page.keyboard.type(code);
+}
+
+test("user can enable 2FA and sign in with a TOTP code", async ({ page }) => {
+	await gotoAndWaitForAppReady(page, "/settings");
+
+	const username = await page.locator("#username").inputValue();
+
+	await page.getByRole("button", { name: "Enable 2FA" }).click();
+	await page.getByRole("textbox", { name: "Password" }).fill(workerPassword);
+	await page.getByRole("button", { name: "Continue" }).click();
+
+	await expect(page.getByRole("heading", { name: "Scan QR Code" })).toBeVisible();
+	const secret = await page.locator("input[readonly]").inputValue();
+
+	await page.getByRole("button", { name: "Continue" }).click();
+	await expect(page.getByRole("heading", { name: "Verify setup" })).toBeVisible();
+
+	await fillOtp(page, await generateTotp(secret));
+
+	await expect(page.getByText(/Status:\s*Enabled/)).toBeVisible();
+
+	await page.context().clearCookies();
+	await gotoAndWaitForAppReady(page, "/login");
+
+	await page.getByRole("textbox", { name: "Username" }).fill(username);
+	await page.getByRole("textbox", { name: "Password" }).fill(workerPassword);
+	await page.getByRole("button", { name: "Login" }).click();
+
+	await expect(page.getByRole("heading", { name: "Two-Factor Authentication" })).toBeVisible();
+
+	await fillOtp(page, await generateTotp(secret));
+
+	await expect(page).toHaveURL("/volumes");
+	await expect(page.getByRole("heading", { name: "No volume" })).toBeVisible();
+});

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
 		"zod": "^4.4.3"
 	},
 	"devDependencies": {
+		"@better-auth/utils": "0.4.0",
 		"@effect/language-service": "^0.86.1",
 		"@faker-js/faker": "^10.4.0",
 		"@hey-api/openapi-ts": "^0.97.1",


### PR DESCRIPTION
This PR supersedes #912 by setting it to `true` by default for existing 2FA to still work and add an e2e test to validate 2fa work correctly in all next releases