### PR TITLE
fix(sso) auto linking local account

### DIFF
--- a/app/server/lib/auth.ts
+++ b/app/server/lib/auth.ts
@@ -125,6 +125,7 @@ export const auth = betterAuth({
 	account: {
 		accountLinking: {
 			enabled: true,
+			requireLocalEmailVerified: false,
 			trustedProviders: ssoIntegration.resolveTrustedProviders,
 		},
 	},

--- a/app/server/modules/sso/__tests__/sso.integration.test.ts
+++ b/app/server/modules/sso/__tests__/sso.integration.test.ts
@@ -103,7 +103,10 @@ describe("ssoIntegration.resolveOrgMembership", () => {
 		expect(membership?.organizationId).toBe(organizationId);
 		expect(membership?.role).toBe("member");
 
-		const updatedInvitations = await db.select().from(invitation).where(eq(invitation.organizationId, organizationId));
+		const updatedInvitations = await db
+			.select()
+			.from(invitation)
+			.where(eq(invitation.organizationId, organizationId));
 		const updatedInvitation = updatedInvitations.find((i) => i.email === "invited@example.com");
 		expect(updatedInvitation?.status).toBe("accepted");
 	});
@@ -341,7 +344,10 @@ describe("ssoIntegration.resolveOrgMembership", () => {
 
 		expect(membership.organizationId).toBe(invitedOrgId);
 
-		const [updatedInvitation] = await db.select().from(invitation).where(eq(invitation.organizationId, invitedOrgId));
+		const [updatedInvitation] = await db
+			.select()
+			.from(invitation)
+			.where(eq(invitation.organizationId, invitedOrgId));
 		expect(updatedInvitation.status).toBe("accepted");
 	});
 });
@@ -359,7 +365,9 @@ describe("ssoIntegration.canLinkSsoAccount", () => {
 	async function setupOrgWithProvider(providerId: string, autoLinkMatchingEmails = false) {
 		const orgId = randomId();
 		const ownerId = await createUser(`owner-${randomSlug("u")}@example.com`, randomSlug("owner"));
-		await db.insert(organization).values({ id: orgId, name: "Acme", slug: randomSlug("acme"), createdAt: new Date() });
+		await db
+			.insert(organization)
+			.values({ id: orgId, name: "Acme", slug: randomSlug("acme"), createdAt: new Date() });
 		await db.insert(ssoProvider).values({
 			id: randomId(),
 			providerId,
@@ -372,7 +380,10 @@ describe("ssoIntegration.canLinkSsoAccount", () => {
 		return { orgId, ownerId };
 	}
 
-	const autoLinkingStates = [false, true] as const;
+	const autoLinkingCases = [
+		{ autoLinkingEnabled: false, autoLinkingLabel: "disabled" },
+		{ autoLinkingEnabled: true, autoLinkingLabel: "enabled" },
+	] as const;
 
 	test("allows linking for a user who is already a member of the org", async () => {
 		const { orgId } = await setupOrgWithProvider("oidc-acme");
@@ -390,8 +401,9 @@ describe("ssoIntegration.canLinkSsoAccount", () => {
 		expect(allowed).toBe(true);
 	});
 
-	for (const autoLinkingEnabled of autoLinkingStates) {
-		test(`allows linking for a new SSO user with a valid pending invitation (auto-linking ${autoLinkingEnabled ? "enabled" : "disabled"})`, async () => {
+	test.each(autoLinkingCases)(
+		"allows linking for a new SSO user with a valid pending invitation (auto-linking $autoLinkingLabel)",
+		async ({ autoLinkingEnabled }) => {
 			const providerId = `oidc-acme-${autoLinkingEnabled ? "on" : "off"}`;
 			const { orgId, ownerId } = await setupOrgWithProvider(providerId, autoLinkingEnabled);
 			const userId = await createUser("alice@example.com", randomSlug("alice"));
@@ -409,9 +421,12 @@ describe("ssoIntegration.canLinkSsoAccount", () => {
 			const allowed = await ssoIntegration.canLinkSsoAccount(userId, providerId);
 
 			expect(allowed).toBe(true);
-		});
+		},
+	);
 
-		test(`blocks linking for an existing user account even with a pending invitation (auto-linking ${autoLinkingEnabled ? "enabled" : "disabled"})`, async () => {
+	test.each(autoLinkingCases)(
+		"allows linking for an existing user account with a pending invitation when auto-linking is $autoLinkingLabel",
+		async ({ autoLinkingEnabled }) => {
 			const providerId = `oidc-acme-${autoLinkingEnabled ? "on" : "off"}`;
 			const { orgId, ownerId } = await setupOrgWithProvider(providerId, autoLinkingEnabled);
 			const userId = await createUserWithCredentialAccount("alice@example.com", randomSlug("alice"));
@@ -428,9 +443,9 @@ describe("ssoIntegration.canLinkSsoAccount", () => {
 
 			const allowed = await ssoIntegration.canLinkSsoAccount(userId, providerId);
 
-			expect(allowed).toBe(false);
-		});
-	}
+			expect(allowed).toBe(autoLinkingEnabled);
+		},
+	);
 
 	test("blocks linking for a user with no membership and no invitation in the org", async () => {
 		await setupOrgWithProvider("oidc-acme");

--- a/app/server/modules/sso/sso.integration.ts
+++ b/app/server/modules/sso/sso.integration.ts
@@ -94,15 +94,6 @@ async function canLinkSsoAccount(userId: string, providerId: string): Promise<bo
 		return true;
 	}
 
-	const existingAccount = await db.query.account.findFirst({
-		where: { userId },
-		columns: { id: true },
-	});
-
-	if (existingAccount) {
-		return false;
-	}
-
 	const user = await db.query.usersTable.findFirst({ where: { id: userId } });
 	if (!user) {
 		return false;
@@ -113,7 +104,16 @@ async function canLinkSsoAccount(userId: string, providerId: string): Promise<bo
 		normalizeEmail(user.email),
 	);
 
-	return !!pendingInvitation;
+	if (!pendingInvitation) {
+		return false;
+	}
+
+	const existingAccount = await db.query.account.findFirst({
+		where: { userId },
+		columns: { id: true },
+	});
+
+	return !existingAccount || ssoProviderRecord.autoLinkMatchingEmails;
 }
 
 async function resolveOrgMembershipOrThrow(userId: string, ctx: GenericEndpointContext | null) {

--- a/app/server/modules/sso/sso.service.ts
+++ b/app/server/modules/sso/sso.service.ts
@@ -26,7 +26,7 @@ class SsoService {
 	async getSsoProviderById(providerId: string) {
 		return db.query.ssoProvider.findFirst({
 			where: { providerId },
-			columns: { id: true, providerId: true, organizationId: true },
+			columns: { id: true, providerId: true, organizationId: true, autoLinkMatchingEmails: true },
 		});
 	}
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -95,7 +95,7 @@ services:
       - TINYAUTH_OIDC_PUBLICKEYPATH=/data/tinyauth_oidc_key.pub
       - TINYAUTH_OIDC_CLIENTS_ZEROBYTE_CLIENTID=zerobyte-test
       - TINYAUTH_OIDC_CLIENTS_ZEROBYTE_CLIENTSECRET=test-secret-12345
-      - TINYAUTH_OIDC_CLIENTS_ZEROBYTE_TRUSTEDREDIRECTURIS=http://localhost:4096/api/auth/sso/callback/test-oidc-register,http://localhost:4096/api/auth/sso/callback/test-oidc-uninvited,http://localhost:4096/api/auth/sso/callback/test-oidc-invited,http://localhost:4096/api/auth/sso/callback/test-oidc-autolink
+      - TINYAUTH_OIDC_CLIENTS_ZEROBYTE_TRUSTEDREDIRECTURIS=http://localhost:4096/api/auth/sso/callback/test-oidc-register,http://localhost:4096/api/auth/sso/callback/test-oidc-uninvited,http://localhost:4096/api/auth/sso/callback/test-oidc-invited,http://localhost:4096/api/auth/sso/callback/test-oidc-autolink,http://localhost:4096/api/auth/sso/callback/test-oidc-existing-member
       - TINYAUTH_OIDC_CLIENTS_ZEROBYTE_NAME=Zerobyte Test
       - TINYAUTH_LOG_LEVEL=debug
       - TINYAUTH_LOG_JSON=true

--- a/e2e/0003-oidc.spec.ts
+++ b/e2e/0003-oidc.spec.ts
@@ -16,6 +16,7 @@ const providerIds = {
 	invited: "test-oidc-invited",
 	autoLinkNoInvite: "test-oidc-register",
 	autoLink: "test-oidc-autolink",
+	existingMember: "test-oidc-existing-member",
 } as const;
 
 const tinyauthPassword = "password";
@@ -25,6 +26,8 @@ const autoLinkUninvitedLocalEmail = "linkguard@example.com";
 const autoLinkTargetEmail = "test@example.com";
 const autoLinkTargetUsername = "sso-link-target";
 const autoLinkUninvitedLocalUsername = "sso-link-guard";
+const existingMemberLocalEmail = "memberlink@example.com";
+const existingMemberLocalUsername = "sso-existing-member";
 const inviteOnlyMessage =
 	"Access is invite-only. Ask an organization admin to send you an invitation before signing in with SSO.";
 const accountLinkRequiredMessage =
@@ -41,9 +44,16 @@ type OrgMembersResponse = {
 
 type SsoSettingsResponse = {
 	invitations: {
+		id: string;
 		email: string;
 		status: string;
 	}[];
+};
+
+type CreateUserResponse = {
+	user?: {
+		id?: string;
+	};
 };
 
 type SsoSignInResponse = {
@@ -114,6 +124,40 @@ async function createLocalUser(browser: Browser, email: string, username: string
 		if (!response.ok()) {
 			throw new Error(`Failed to create local user ${email}: ${await response.text()}`);
 		}
+
+		const body = (await response.json()) as CreateUserResponse;
+		if (!body.user?.id) {
+			throw new Error(`Create user response missing id for ${email}`);
+		}
+
+		return body.user.id;
+	} finally {
+		await adminContext.close();
+	}
+}
+
+async function verifyLocalUserEmail(browser: Browser, userId: string) {
+	const adminContext = await browser.newContext({
+		baseURL: appBaseUrl,
+		storageState: setupAuthFile,
+	});
+
+	try {
+		const response = await adminContext.request.post("/api/auth/admin/update-user", {
+			headers: {
+				Origin: appBaseUrl,
+			},
+			data: {
+				userId,
+				data: {
+					emailVerified: true,
+				},
+			},
+		});
+
+		if (!response.ok()) {
+			throw new Error(`Failed to verify local user ${userId}: ${await response.text()}`);
+		}
 	} finally {
 		await adminContext.close();
 	}
@@ -148,7 +192,7 @@ async function removeOrgMemberById(page: Page, memberId: string) {
 	}
 }
 
-async function getInvitationStatusByEmail(page: Page, email: string) {
+async function getInvitationByEmail(page: Page, email: string) {
 	const response = await page.request.get("/api/v1/auth/sso-settings", {
 		headers: {
 			Origin: appBaseUrl,
@@ -160,9 +204,60 @@ async function getInvitationStatusByEmail(page: Page, email: string) {
 	}
 
 	const body = (await response.json()) as SsoSettingsResponse;
-	const invitation = body.invitations.find((entry) => entry.email.toLowerCase() === email.toLowerCase());
+	return body.invitations.find((entry) => entry.email.toLowerCase() === email.toLowerCase()) ?? null;
+}
+
+async function getInvitationStatusByEmail(page: Page, email: string) {
+	const invitation = await getInvitationByEmail(page, email);
 
 	return invitation?.status ?? null;
+}
+
+async function getInvitationIdByEmail(page: Page, email: string) {
+	const invitation = await getInvitationByEmail(page, email);
+
+	return invitation?.id ?? null;
+}
+
+async function acceptInvitationAsLocalUser(browser: Browser, email: string, invitationId: string) {
+	const context = await browser.newContext({
+		baseURL: appBaseUrl,
+		storageState: {
+			cookies: [],
+			origins: [],
+		},
+	});
+
+	try {
+		const signInResponse = await context.request.post("/api/auth/sign-in/email", {
+			headers: {
+				Origin: appBaseUrl,
+			},
+			data: {
+				email,
+				password: tinyauthPassword,
+			},
+		});
+
+		if (!signInResponse.ok()) {
+			throw new Error(`Failed to sign in local user ${email}: ${await signInResponse.text()}`);
+		}
+
+		const acceptResponse = await context.request.post("/api/auth/organization/accept-invitation", {
+			headers: {
+				Origin: appBaseUrl,
+			},
+			data: {
+				invitationId,
+			},
+		});
+
+		if (!acceptResponse.ok()) {
+			throw new Error(`Failed to accept invitation ${invitationId} for ${email}: ${await acceptResponse.text()}`);
+		}
+	} finally {
+		await context.close();
+	}
 }
 
 async function setProviderAutoLinking(page: Page, providerId: string, enabled: boolean) {
@@ -429,4 +524,39 @@ test("auto-link policy enforces invitation and controls account linking", async 
 			return getOrgMemberIdByEmail(page, autoLinkTargetEmail);
 		})
 		.not.toBeNull();
+});
+
+test("existing local org members can link via SSO without a pending invitation", async ({ page, browser }) => {
+	await registerOidcProvider(page, providerIds.existingMember);
+	const userId = await createLocalUser(browser, existingMemberLocalEmail, existingMemberLocalUsername);
+	await verifyLocalUserEmail(browser, userId);
+	await createPendingInvitation(page, existingMemberLocalEmail);
+
+	const invitationId = await getInvitationIdByEmail(page, existingMemberLocalEmail);
+
+	if (!invitationId) {
+		throw new Error(`Missing invitation for ${existingMemberLocalEmail}`);
+	}
+
+	await acceptInvitationAsLocalUser(browser, existingMemberLocalEmail, invitationId);
+
+	await expect
+		.poll(async () => {
+			return getInvitationStatusByEmail(page, existingMemberLocalEmail);
+		})
+		.toBe("accepted");
+
+	await expect
+		.poll(async () => {
+			return getOrgMemberIdByEmail(page, existingMemberLocalEmail);
+		})
+		.not.toBeNull();
+
+	await setProviderAutoLinking(page, providerIds.existingMember, true);
+
+	await withOidcLoginAttempt(browser, providerIds.existingMember, existingMemberLocalEmail, async (ssoPage) => {
+		await ssoPage.waitForURL(/\/volumes/, { timeout: 30000 });
+		await waitForAppReady(ssoPage);
+		await expect(ssoPage).toHaveURL(/\/volumes/);
+	});
 });

--- a/e2e/0003-oidc.spec.ts
+++ b/e2e/0003-oidc.spec.ts
@@ -413,6 +413,20 @@ test("auto-link policy enforces invitation and controls account linking", async 
 	await setProviderAutoLinking(page, providerIds.autoLink, true);
 
 	await withOidcLoginAttempt(browser, providerIds.autoLink, autoLinkTargetEmail, async (ssoPage) => {
-		await expectAccountLinkRequiredLoginError(ssoPage);
+		await ssoPage.waitForURL(/\/volumes/, { timeout: 30000 });
+		await waitForAppReady(ssoPage);
+		await expect(ssoPage).toHaveURL(/\/volumes/);
 	});
+
+	await expect
+		.poll(async () => {
+			return getInvitationStatusByEmail(page, autoLinkTargetEmail);
+		})
+		.toBe("accepted");
+
+	await expect
+		.poll(async () => {
+			return getOrgMemberIdByEmail(page, autoLinkTargetEmail);
+		})
+		.not.toBeNull();
 });

--- a/playwright/tinyauth/users.txt
+++ b/playwright/tinyauth/users.txt
@@ -3,3 +3,4 @@ user@example.com:$2a$10$2b2cU8CPhOTaGrs1HRQuAueS7JTT5ZHsHSzYiFPm1leZck7Mc8T4W
 test@example.com:$2a$10$2b2cU8CPhOTaGrs1HRQuAueS7JTT5ZHsHSzYiFPm1leZck7Mc8T4W
 test@test.com:$2a$10$2b2cU8CPhOTaGrs1HRQuAueS7JTT5ZHsHSzYiFPm1leZck7Mc8T4W
 linkguard@example.com:$2a$10$2b2cU8CPhOTaGrs1HRQuAueS7JTT5ZHsHSzYiFPm1leZck7Mc8T4W
+memberlink@example.com:$2a$10$2b2cU8CPhOTaGrs1HRQuAueS7JTT5ZHsHSzYiFPm1leZck7Mc8T4W


### PR DESCRIPTION
If an account is already part of the org and auto linking is enabled for the provider, the login should pass with same email users