### PR TITLE
fix(backups): skip warning messages on exit code 0

### DIFF
--- a/app/server/modules/backups/__tests__/backups.service.execution.test.ts
+++ b/app/server/modules/backups/__tests__/backups.service.execution.test.ts
@@ -648,6 +648,45 @@ describe("stop backup", () => {
 		);
 	});
 
+	test("should not warn when restic exits successfully with diagnostic stderr", async () => {
+		const { resticBackupMock } = setup();
+		const notificationSpy = vi.spyOn(notificationsService, "sendBackupNotification").mockResolvedValue();
+		const volume = await createTestVolume();
+		const repository = await createTestRepository();
+		const schedule = await createTestBackupSchedule({
+			volumeId: volume.id,
+			repositoryId: repository.id,
+		});
+
+		resticBackupMock.mockImplementationOnce((params: SafeSpawnParams) => {
+			params.onStderr?.("Load(<lock/b84b958297>, 0, 0) failed: Key not found");
+
+			return Promise.resolve({
+				exitCode: 0,
+				summary: generateBackupOutput(),
+				error: "",
+			});
+		});
+
+		await backupsService.executeBackup(schedule.id);
+
+		const updatedSchedule = await getScheduleByIdOrShortId(schedule.id);
+		const task = await getBackupTaskForSchedule(schedule.id);
+		expect(updatedSchedule.lastBackupStatus).toBe("success");
+		expect(updatedSchedule.lastBackupError).toBeNull();
+		expect(task?.status).toBe("succeeded");
+		expect(task?.result).toMatchObject({
+			kind: "backup",
+			exitCode: 0,
+			warningDetails: null,
+		});
+		expect(notificationSpy).toHaveBeenLastCalledWith(
+			schedule.id,
+			"success",
+			expect.objectContaining({ error: undefined }),
+		);
+	});
+
 	test("should store restic diagnostic details instead of the generic summary on hard failure", async () => {
 		const { resticBackupMock } = setup();
 		const volume = await createTestVolume();

--- a/app/test/helpers/agent-mock.ts
+++ b/app/test/helpers/agent-mock.ts
@@ -72,7 +72,7 @@ export const createAgentBackupMocks = (
 							status: "completed",
 							exitCode: result.exitCode,
 							result: fromAny(parsedResult),
-							warningDetails: stderrLines.join("\n") || null,
+							warningDetails: result.exitCode === 0 ? null : stderrLines.join("\n") || null,
 						});
 						return;
 					}

--- a/packages/core/src/restic/commands/__tests__/backup.test.ts
+++ b/packages/core/src/restic/commands/__tests__/backup.test.ts
@@ -280,12 +280,43 @@ describe("backup command", () => {
 			expect(result?.snapshot_id).toBe("abcd1234");
 		});
 
+		test("ignores restic diagnostic stderr on exit code 0", async () => {
+			setup({
+				onSpawnCall: (params) => {
+					params.onStderr?.("Load(<lock/b84b958297>, 0, 0) failed: Key not found");
+				},
+			});
+
+			const { exitCode, warningDetails } = await runBackup(
+				config,
+				"/mnt/data",
+				{ organizationId: "org-1" },
+				mockDeps,
+			);
+
+			expect(exitCode).toBe(0);
+			expect(warningDetails).toBeNull();
+		});
+
 		test("returns result without throwing on exit code 3 (partial read errors)", async () => {
 			setup({ spawnResult: { exitCode: 3 } });
 			const { result, exitCode } = await runBackup(config, "/mnt/data", { organizationId: "org-1" }, mockDeps);
 
 			expect(exitCode).toBe(3);
 			expect(result).not.toBeNull();
+		});
+
+		test("keeps restic stderr on exit code 3", async () => {
+			setup({
+				spawnResult: { exitCode: 3 },
+				onSpawnCall: (params) => {
+					params.onStderr?.("error: open /mnt/data/private.db: permission denied");
+				},
+			});
+
+			const { warningDetails } = await runBackup(config, "/mnt/data", { organizationId: "org-1" }, mockDeps);
+
+			expect(warningDetails).toBe("error: open /mnt/data/private.db: permission denied");
 		});
 
 		test("throws ResticError on non-zero, non-3 exit codes", async () => {

--- a/packages/core/src/restic/commands/backup.ts
+++ b/packages/core/src/restic/commands/backup.ts
@@ -170,6 +170,9 @@ export const backup = (
 				},
 			});
 
+			const stderrDetails = stderrLines.length > 0 ? stderrLines.join("\n") : null;
+			const warningDetails = res.exitCode === 0 ? null : stderrDetails;
+
 			if (includeFile) {
 				await fs.unlink(includeFile).catch(() => {});
 			}
@@ -194,7 +197,7 @@ export const backup = (
 				logger.error(`Restic backup failed: ${res.error}`);
 				logger.error(`Command executed: restic ${args.join(" ")}`);
 
-				throw createResticError(res.exitCode, stderrLines.join("\n") || res.stderr || res.error);
+				throw createResticError(res.exitCode, stderrDetails || res.stderr || res.error);
 			}
 
 			const lastLine = res.summary.trim();
@@ -214,14 +217,14 @@ export const backup = (
 				return {
 					result: null,
 					exitCode: res.exitCode,
-					warningDetails: stderrLines.length > 0 ? stderrLines.join("\n") : null,
+					warningDetails,
 				};
 			}
 
 			return {
 				result: result.data,
 				exitCode: res.exitCode,
-				warningDetails: stderrLines.length > 0 ? stderrLines.join("\n") : null,
+				warningDetails,
 			};
 		},
 		catch: (error) => {


### PR DESCRIPTION
re-trying due to failed codeql

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of diagnostic messages from backup operations. Successful backups that generate diagnostic output are now correctly reported as successes instead of warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->