### PR TITLE
fix: restore trackpad swipe-back navigation

### DIFF
--- a/app/app.css
+++ b/app/app.css
@@ -32,7 +32,7 @@ body {
 @media (min-width: 48rem) {
 	html,
 	body {
-		overscroll-behavior: none;
+		overscroll-behavior-y: none;
 	}
 }
 


### PR DESCRIPTION
macOS style standard swipe-to-navigate-back behavior is broken by `overscroll-behavior: none`. Changing this to only disable overscroll in the vertical (`y`) direction restores swipe to go forward/back behavior that is standard on the web.