### PR TITLE
feat: Add API token support via @better-auth/api-key

### DIFF
--- a/app/client/lib/auth-client.ts
+++ b/app/client/lib/auth-client.ts
@@ -8,6 +8,7 @@ import {
 } from "better-auth/client/plugins";
 import { ssoClient } from "@better-auth/sso/client";
 import { passkeyClient } from "@better-auth/passkey/client";
+import { apiKeyClient } from "@better-auth/api-key/client";
 import type { auth } from "~/server/lib/auth";
 
 export const authClient = createAuthClient({
@@ -19,5 +20,6 @@ export const authClient = createAuthClient({
 		ssoClient(),
 		twoFactorClient(),
 		passkeyClient(),
+		apiKeyClient(),
 	],
 });

--- a/app/client/modules/settings/components/api-tokens-section.tsx
+++ b/app/client/modules/settings/components/api-tokens-section.tsx
@@ -1,0 +1,232 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Copy, KeyRound, Plus, Trash2, X } from "lucide-react";
+import { useState } from "react";
+import { toast } from "sonner";
+import { Button } from "~/client/components/ui/button";
+import { Card, CardContent, CardDescription, CardTitle } from "~/client/components/ui/card";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+	DialogTrigger,
+} from "~/client/components/ui/dialog";
+import { Input } from "~/client/components/ui/input";
+import { Label } from "~/client/components/ui/label";
+import { authClient } from "~/client/lib/auth-client";
+import { logger } from "~/client/lib/logger";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "~/client/components/ui/table";
+import { Badge } from "~/client/components/ui/badge";
+
+export function ApiTokensSection() {
+	const [createDialogOpen, setCreateDialogOpen] = useState(false);
+	const [tokenName, setTokenName] = useState("");
+	const [createdKey, setCreatedKey] = useState<string | null>(null);
+	const queryClient = useQueryClient();
+
+	const { data: apiKeysData, isLoading } = useQuery({
+		queryKey: ["apiKeys"],
+		queryFn: async () => {
+			const result = await authClient.apiKey.list();
+			return result.data;
+		},
+	});
+
+	const createMutation = useMutation({
+		mutationFn: async (name: string) => {
+			const result = await authClient.apiKey.create({
+				name,
+				expiresIn: 90 * 24 * 60 * 60 * 1000, // 90 days
+			});
+			return result.data;
+		},
+		onSuccess: (data) => {
+			if (data?.key) {
+				setCreatedKey(data.key);
+			}
+			void queryClient.invalidateQueries({ queryKey: ["apiKeys"] });
+			toast.success("API token created");
+		},
+		onError: (error) => {
+			logger.error(error);
+			toast.error("Failed to create API token");
+		},
+	});
+
+	const deleteMutation = useMutation({
+		mutationFn: async (keyId: string) => {
+			await authClient.apiKey.delete({ keyId });
+		},
+		onSuccess: () => {
+			void queryClient.invalidateQueries({ queryKey: ["apiKeys"] });
+			toast.success("API token revoked");
+		},
+		onError: (error) => {
+			logger.error(error);
+			toast.error("Failed to revoke API token");
+		},
+	});
+
+	const handleCreate = () => {
+		if (!tokenName.trim()) {
+			toast.error("Name is required");
+			return;
+		}
+		createMutation.mutate(tokenName);
+	};
+
+	const handleCopyKey = () => {
+		if (createdKey) {
+			void navigator.clipboard.writeText(createdKey);
+			toast.success("API token copied to clipboard");
+		}
+	};
+
+	const handleCloseDialog = () => {
+		setCreateDialogOpen(false);
+		setTokenName("");
+		setCreatedKey(null);
+	};
+
+	const handleDelete = (id: string) => {
+		if (window.confirm("Are you sure you want to revoke this API token? This action cannot be undone.")) {
+			deleteMutation.mutate(id);
+		}
+	};
+
+	return (
+		<>
+			<Card className="p-0 gap-0">
+				<div className="border-b border-border/50 bg-card-header p-6">
+					<div className="flex items-center justify-between">
+						<div>
+							<CardTitle className="flex items-center gap-2">
+								<KeyRound className="size-5" />
+								API Tokens
+							</CardTitle>
+							<CardDescription className="mt-1.5">
+								Manage API tokens for programmatic access to Zerobyte
+							</CardDescription>
+						</div>
+						<Dialog open={createDialogOpen} onOpenChange={setCreateDialogOpen}>
+							<DialogTrigger asChild>
+								<Button size="sm">
+									<Plus className="size-4 mr-1" />
+									Create Token
+								</Button>
+							</DialogTrigger>
+							<DialogContent>
+								{createdKey ? (
+									<>
+										<DialogHeader>
+											<DialogTitle>API Token Created</DialogTitle>
+											<DialogDescription>
+												Copy your API token now. It will not be shown again.
+											</DialogDescription>
+										</DialogHeader>
+										<div className="space-y-4 py-4">
+											<div className="relative">
+												<Input
+													value={createdKey}
+													readOnly
+													className="font-mono text-sm pr-10"
+												/>
+												<Button
+													variant="ghost"
+													size="icon"
+													className="absolute right-0 top-0 h-full px-3"
+													onClick={handleCopyKey}
+												>
+													<Copy className="size-4" />
+												</Button>
+											</div>
+										</div>
+										<DialogFooter>
+											<Button onClick={handleCloseDialog}>Done</Button>
+										</DialogFooter>
+									</>
+								) : (
+									<>
+										<DialogHeader>
+											<DialogTitle>Create API Token</DialogTitle>
+											<DialogDescription>
+												Create a new API token for programmatic access. The token will expire in
+												90 days.
+											</DialogDescription>
+										</DialogHeader>
+										<div className="space-y-4 py-4">
+											<div className="space-y-2">
+												<Label htmlFor="token-name">Name</Label>
+												<Input
+													id="token-name"
+													value={tokenName}
+													onChange={(e) => setTokenName(e.target.value)}
+													placeholder="e.g., mcp-server, ci-cd"
+												/>
+											</div>
+										</div>
+										<DialogFooter>
+											<Button variant="outline" onClick={() => setCreateDialogOpen(false)}>
+												<X className="h-4 w-4 mr-2" />
+												Cancel
+											</Button>
+											<Button onClick={handleCreate} loading={createMutation.isPending}>
+												Create
+											</Button>
+										</DialogFooter>
+									</>
+								)}
+							</DialogContent>
+						</Dialog>
+					</div>
+				</div>
+				<CardContent className="p-6">
+					{isLoading ? (
+						<p className="text-sm text-muted-foreground">Loading...</p>
+					) : !apiKeysData?.apiKeys?.length ? (
+						<p className="text-sm text-muted-foreground">No API tokens yet. Create one to get started.</p>
+					) : (
+						<Table>
+							<TableHeader>
+								<TableRow>
+									<TableHead>Name</TableHead>
+									<TableHead>Prefix</TableHead>
+									<TableHead>Created</TableHead>
+									<TableHead>Expires</TableHead>
+									<TableHead>Status</TableHead>
+									<TableHead className="w-[70px]" />
+								</TableRow>
+							</TableHeader>
+							<TableBody>
+								{apiKeysData.apiKeys.map((key) => (
+									<TableRow key={key.id}>
+										<TableCell className="font-medium">{key.name || "Unnamed"}</TableCell>
+										<TableCell className="font-mono text-sm">
+											{key.start || key.prefix || "—"}
+										</TableCell>
+										<TableCell>{new Date(key.createdAt).toLocaleDateString()}</TableCell>
+										<TableCell>
+											{key.expiresAt ? new Date(key.expiresAt).toLocaleDateString() : "Never"}
+										</TableCell>
+										<TableCell>
+											<Badge variant={key.enabled !== false ? "default" : "secondary"}>
+												{key.enabled !== false ? "Active" : "Disabled"}
+											</Badge>
+										</TableCell>
+										<TableCell>
+											<Button variant="ghost" size="icon" onClick={() => handleDelete(key.id)}>
+												<Trash2 className="size-4 text-destructive" />
+											</Button>
+										</TableCell>
+									</TableRow>
+								))}
+							</TableBody>
+						</Table>
+					)}
+				</CardContent>
+			</Card>
+		</>
+	);
+}

--- a/app/client/modules/settings/routes/settings.tsx
+++ b/app/client/modules/settings/routes/settings.tsx
@@ -51,6 +51,7 @@ import { useNavigate, useSearch } from "@tanstack/react-router";
 import { SsoSettingsSection } from "~/client/modules/sso/components/sso-settings-section";
 import { OrgMembersSection } from "../components/org-members-section";
 import { PendingInvitationsSection } from "../components/pending-invitations-section";
+import { ApiTokensSection } from "../components/api-tokens-section";
 import { useOrganizationContext } from "~/client/hooks/use-org-context";
 import { cn } from "~/client/lib/utils";
 
@@ -231,6 +232,7 @@ export function SettingsPage({
 			<Tabs value={activeTab} onValueChange={onTabChange} className="w-full">
 				<TabsList>
 					<TabsTrigger value="account">Account</TabsTrigger>
+					<TabsTrigger value="api-tokens">API Tokens</TabsTrigger>
 					{isOrgAdmin && <TabsTrigger value="organization">Organization</TabsTrigger>}
 				</TabsList>
 
@@ -479,6 +481,10 @@ export function SettingsPage({
 
 							<PasskeysSection />
 						</Card>
+					</TabsContent>
+
+					<TabsContent value="api-tokens" className="mt-0">
+						<ApiTokensSection />
 					</TabsContent>
 
 					{isOrgAdmin && (

--- a/app/server/db/schema.ts
+++ b/app/server/db/schema.ts
@@ -574,3 +574,34 @@ export const passkey = sqliteTable(
 	(table) => [index("passkey_userId_idx").on(table.userId), index("passkey_credentialID_idx").on(table.credentialID)],
 );
 export type Passkey = typeof passkey.$inferSelect;
+
+export const apikey = sqliteTable("apikey", {
+	id: text("id").primaryKey(),
+	configId: text("config_id").notNull().default("default"),
+	name: text("name"),
+	start: text("start"),
+	prefix: text("prefix"),
+	key: text("key").notNull(),
+	referenceId: text("reference_id").notNull(),
+	refillInterval: integer("refill_interval"),
+	refillAmount: integer("refill_amount"),
+	lastRefillAt: int("last_refill_at", { mode: "timestamp_ms" }),
+	enabled: integer("enabled", { mode: "boolean" }).notNull().default(true),
+	rateLimitEnabled: integer("rate_limit_enabled", { mode: "boolean" }),
+	rateLimitTimeWindow: integer("rate_limit_time_window"),
+	rateLimitMax: integer("rate_limit_max"),
+	requestCount: integer("request_count").notNull().default(0),
+	remaining: integer("remaining"),
+	lastRequest: int("last_request", { mode: "timestamp_ms" }),
+	expiresAt: int("expires_at", { mode: "timestamp_ms" }),
+	createdAt: int("created_at", { mode: "timestamp_ms" })
+		.notNull()
+		.default(sql`(unixepoch() * 1000)`),
+	updatedAt: int("updated_at", { mode: "timestamp_ms" })
+		.notNull()
+		.$onUpdate(() => new Date())
+		.default(sql`(unixepoch() * 1000)`),
+	permissions: text("permissions"),
+	metadata: text("metadata"),
+});
+export type ApiKey = typeof apikey.$inferSelect;

--- a/app/server/lib/auth.ts
+++ b/app/server/lib/auth.ts
@@ -13,6 +13,7 @@ import { apiKey } from "@better-auth/api-key";
 import { createAuthMiddleware } from "better-auth/api";
 import { config } from "../core/config";
 import { db } from "../db/db";
+import * as schema from "../db/schema";
 import { cryptoUtils } from "../utils/crypto";
 import { authService } from "../modules/auth/auth.service";
 import { tanstackStartCookies } from "better-auth/tanstack-start";
@@ -58,6 +59,7 @@ export const auth = betterAuth({
 	},
 	database: drizzleAdapter(db, {
 		provider: "sqlite",
+		schema,
 	}),
 	databaseHooks: {
 		account: {

--- a/app/server/lib/auth.ts
+++ b/app/server/lib/auth.ts
@@ -9,6 +9,7 @@ import { APIError } from "better-auth/api";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { admin, twoFactor, username, organization, testUtils } from "better-auth/plugins";
 import { passkey } from "@better-auth/passkey";
+import { apiKey } from "@better-auth/api-key";
 import { createAuthMiddleware } from "better-auth/api";
 import { config } from "../core/config";
 import { db } from "../db/db";
@@ -195,6 +196,10 @@ export const auth = betterAuth({
 					});
 				},
 			},
+		}),
+		apiKey({
+			enableSessionForAPIKeys: true,
+			defaultPrefix: "zb_",
 		}),
 		tanstackStartCookies(),
 		...(process.env.NODE_ENV === "test" ? [testUtils()] : []),

--- a/app/server/modules/auth/auth.middleware.ts
+++ b/app/server/modules/auth/auth.middleware.ts
@@ -26,11 +26,24 @@ export const requireAuth = createMiddleware(async (c, next) => {
 		headers: c.req.raw.headers,
 	});
 
-	const { user, session } = sess ?? {};
-	const { activeOrganizationId } = session ?? {};
+	let { user, session } = sess ?? {};
+	let { activeOrganizationId } = session ?? {};
 
-	if (!user || !session || !activeOrganizationId) {
+	if (!user || !session) {
 		return c.json<unknown>({ message: "Invalid or expired session" }, 401);
+	}
+
+	if (!activeOrganizationId) {
+		const membership = await db.query.member.findFirst({
+			where: { userId: user.id },
+		});
+		if (membership) {
+			activeOrganizationId = membership.organizationId;
+		}
+	}
+
+	if (!activeOrganizationId) {
+		return c.json<unknown>({ message: "Invalid organization context" }, 403);
 	}
 
 	const membership = await db.query.member.findFirst({

--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "zerobyte",
       "dependencies": {
+        "@better-auth/api-key": "^1.6.14",
         "@better-auth/passkey": "^1.6.15",
         "@better-auth/sso": "^1.6.15",
         "@dnd-kit/core": "^6.3.1",
@@ -269,6 +270,8 @@
     "@base-ui/react": ["@base-ui/react@1.5.0", "", { "dependencies": { "@babel/runtime": "^7.29.2", "@base-ui/utils": "0.2.9", "@floating-ui/react-dom": "^2.1.8", "@floating-ui/utils": "^0.2.11", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "@date-fns/tz": "^1.2.0", "@types/react": "^17 || ^18 || ^19", "date-fns": "^4.0.0", "react": "^17 || ^18 || ^19", "react-dom": "^17 || ^18 || ^19" }, "optionalPeers": ["@date-fns/tz", "@types/react", "date-fns"] }, "sha512-z1gSAlced1yY+iM+mHDEtIkD8UI3Ebs52MuBPxvV6f5hRutk+xvCH/wuB7hDqDzK9JG5FoMz5nhrqtSs1wjt1A=="],
 
     "@base-ui/utils": ["@base-ui/utils@0.2.9", "", { "dependencies": { "@babel/runtime": "^7.29.2", "@floating-ui/utils": "^0.2.11", "reselect": "^5.1.1", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "@types/react": "^17 || ^18 || ^19", "react": "^17 || ^18 || ^19", "react-dom": "^17 || ^18 || ^19" }, "optionalPeers": ["@types/react"] }, "sha512-x/PDDCYzoqPpjrdyb3VcyylTI2IjUXEtYDGi5foh7KsnmNJIIaVwA2GLgDH1dps1GgXiJbA60hM+AyuTfQzIvw=="],
+
+    "@better-auth/api-key": ["@better-auth/api-key@1.6.14", "", { "dependencies": { "zod": "^4.3.6" }, "peerDependencies": { "@better-auth/core": "^1.6.14", "@better-auth/utils": "0.4.1", "better-auth": "^1.6.14", "better-call": "1.3.5" } }, "sha512-iMLRcjpGyegI5yy375ZIw83HZGSZe6TwjtCKWdFTYy1PQ0bUcD0H61uKcvO82Co4jJmjakI3POR6lDy5W1OOew=="],
 
     "@better-auth/core": ["@better-auth/core@1.6.15", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.39.0", "@standard-schema/spec": "^1.1.0", "zod": "^4.3.6" }, "peerDependencies": { "@better-auth/utils": "0.4.1", "@better-fetch/fetch": "1.1.21", "@cloudflare/workers-types": ">=4", "@opentelemetry/api": "^1.9.0", "better-call": "1.3.5", "jose": "^6.1.0", "kysely": "^0.28.5 || ^0.29.0", "nanostores": "^1.0.1" }, "optionalPeers": ["@cloudflare/workers-types", "@opentelemetry/api"] }, "sha512-gPgeEn+2t2cohSKj1CJFCJLo4jNqvtvhKP/y6Uwuurg4ReEf2Y9PUCYffvbp7DDc+GevWTuD0Cv9x0+e83+HpA=="],
 

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
 		"test:codegen": "playwright codegen localhost:4096"
 	},
 	"dependencies": {
+		"@better-auth/api-key": "^1.6.14",
 		"@better-auth/passkey": "^1.6.15",
 		"@better-auth/sso": "^1.6.15",
 		"@dnd-kit/core": "^6.3.1",


### PR DESCRIPTION
## Summary

- Add `@better-auth/api-key` plugin for programmatic API access
- Create API Tokens settings page with full CRUD UI
- Enable session mocking for seamless integration with existing auth middleware

## Changes

### Backend
- `app/server/lib/auth.ts`: Added `apiKey()` plugin configuration
  - User-scoped keys with `zb_` prefix
  - `enableSessionForAPIKeys: true` for automatic session creation

### Frontend
- `app/client/lib/auth-client.ts`: Added `apiKeyClient()` plugin
- `app/client/modules/settings/components/api-tokens-section.tsx`: New UI component
- `app/client/modules/settings/routes/settings.tsx`: Added "API Tokens" tab

## Usage

### Create Token
```bash
curl -X POST /api/auth/api-key/create \
  -H "Content-Type: application/json" \
  -b cookies.txt \
  -d '{"name":"mcp-server"}'
```

### Authenticate
```bash
curl -H "x-api-key: zb_..." /api/v1/volumes
```

## Features
- Create tokens via Settings → API Tokens
- 90-day default expiration
- Enable/disable and revoke tokens
- Compatible with existing `requireAuth` middleware