### PR TITLE
feat(desktop): hide unavailable admin flows

### DIFF
--- a/app/client/components/app-sidebar.tsx
+++ b/app/client/components/app-sidebar.tsx
@@ -18,6 +18,7 @@ import { HoverCard, HoverCardContent, HoverCardTrigger } from "~/client/componen
 import { cn } from "~/client/lib/utils";
 import { APP_VERSION, RCLONE_VERSION, RESTIC_VERSION, SHOUTRRR_VERSION } from "~/client/lib/version";
 import { useUpdates } from "~/client/hooks/use-updates";
+import { usePermissions } from "~/client/hooks/use-permissions";
 import { ReleaseNotesDialog } from "./release-notes-dialog";
 import { OrganizationSwitcher } from "./organization-switcher";
 import { Link } from "@tanstack/react-router";
@@ -50,16 +51,14 @@ const items = [
 	},
 ];
 
-type Props = {
-	isInstanceAdmin: boolean;
-};
-
-export function AppSidebar({ isInstanceAdmin }: Props) {
+export function AppSidebar() {
 	const { state, isMobile, setOpenMobile } = useSidebar();
 	const { updates, hasUpdate } = useUpdates();
+	const permissions = usePermissions();
 	const [showReleaseNotes, setShowReleaseNotes] = useState(false);
 
 	const isCollapsed = state === "collapsed";
+	const showInstanceAdmin = permissions.can("instanceAdministration.view");
 
 	const displayVersion = APP_VERSION.startsWith("v") || APP_VERSION === "dev" ? APP_VERSION : `v${APP_VERSION}`;
 	const releaseUrl =
@@ -71,7 +70,11 @@ export function AppSidebar({ isInstanceAdmin }: Props) {
 		<Sidebar variant="inset" collapsible="icon" className="p-0">
 			<SidebarHeader className="bg-card-header border-b border-border/80 dark:border-border/50 hidden md:flex h-16.25 flex-row items-center p-4">
 				<Link to="/volumes" className="flex items-center gap-3 font-semibold pl-2">
-					<img src="/images/zerobyte.png" alt="Zerobyte Logo" className={cn("h-8 w-8 shrink-0 object-contain -ml-2")} />
+					<img
+						src="/images/zerobyte.png"
+						alt="Zerobyte Logo"
+						className={cn("h-8 w-8 shrink-0 object-contain -ml-2")}
+					/>
 					<span
 						className={cn("text-base transition-all duration-200 -ml-1", {
 							"opacity-0 w-0 overflow-hidden ": isCollapsed,
@@ -101,9 +104,12 @@ export function AppSidebar({ isInstanceAdmin }: Props) {
 															<>
 																{isActive && (
 																	<div
-																		className={cn("absolute left-0 top-0 h-full w-0.75 bg-strong-accent mr-2", {
-																			hidden: isCollapsed,
-																		})}
+																		className={cn(
+																			"absolute left-0 top-0 h-full w-0.75 bg-strong-accent mr-2",
+																			{
+																				hidden: isCollapsed,
+																			},
+																		)}
 																	/>
 																)}
 																<item.icon
@@ -136,7 +142,7 @@ export function AppSidebar({ isInstanceAdmin }: Props) {
 						</SidebarMenu>
 					</SidebarGroupContent>
 				</SidebarGroup>
-				{isInstanceAdmin && (
+				{showInstanceAdmin && (
 					<>
 						<SidebarSeparator />
 						<SidebarGroup>
@@ -157,9 +163,12 @@ export function AppSidebar({ isInstanceAdmin }: Props) {
 																<>
 																	{isActive && (
 																		<div
-																			className={cn("absolute left-0 top-0 h-full w-0.75 bg-strong-accent mr-2", {
-																				hidden: isCollapsed,
-																			})}
+																			className={cn(
+																				"absolute left-0 top-0 h-full w-0.75 bg-strong-accent mr-2",
+																				{
+																					hidden: isCollapsed,
+																				},
+																			)}
 																		/>
 																	)}
 																	<ShieldCheck

--- a/app/client/components/layout.tsx
+++ b/app/client/components/layout.tsx
@@ -11,6 +11,7 @@ import { Outlet, useNavigate } from "@tanstack/react-router";
 import { AppBreadcrumb } from "./app-breadcrumb";
 import { Tooltip, TooltipContent, TooltipTrigger } from "./ui/tooltip";
 import { ThemeToggle } from "./theme-toggle";
+import { PermissionsProvider } from "../hooks/use-permissions";
 
 type Props = {
 	loaderData: AppContext;
@@ -34,64 +35,66 @@ export function Layout({ loaderData }: Props) {
 
 	return (
 		<SidebarProvider defaultOpen={loaderData.sidebarOpen}>
-			<AppSidebar isInstanceAdmin={loaderData.user?.role === "admin"} />
-			<div className="w-full relative flex flex-col min-h-screen md:h-screen md:overflow-hidden">
-				<header className="z-50 bg-card-header border-b border-border/80 dark:border-border/50 shrink-0 h-16.25">
-					<div className="flex items-center h-full justify-between px-2 sm:px-8 mx-auto container gap-4">
-						<div className="flex items-center gap-4 min-w-0">
-							<SidebarTrigger />
-							<AppBreadcrumb />
-						</div>
-						{loaderData.user && (
-							<div className="flex items-center bg-card dark:bg-muted/30 border border-border/80 dark:border-border/50 px-2 py-1 rounded-full shadow-[0_2px_10px_-4px_rgba(0,0,0,0.05)] dark:shadow-sm">
-								<span className="text-sm text-muted-foreground hidden md:inline-flex pl-2 mr-5">
-									<span className="text-foreground">{loaderData.user.name}</span>
-								</span>
-								<ThemeToggle />
-								<Tooltip>
-									<TooltipTrigger asChild>
-										<Button
-											variant="ghost"
-											size="icon"
-											className="rounded-full h-7 text-xs text-muted-foreground hover:text-foreground"
-											onClick={handleLogout}
-										>
-											<LogOut className="w-4 h-4" />
-										</Button>
-									</TooltipTrigger>
-									<TooltipContent>Logout</TooltipContent>
-								</Tooltip>
-								<Tooltip>
-									<TooltipTrigger asChild>
-										<a
-											href="https://github.com/nicotsx/zerobyte/issues/new/choose"
-											target="_blank"
-											rel="noreferrer"
-											className={buttonVariants({
-												variant: "ghost",
-												size: "icon",
-												className:
-													"relative overflow-hidden hidden lg:inline-flex rounded-full h-7 w-7 text-muted-foreground hover:text-foreground",
-											})}
-										>
-											<LifeBuoy className="w-4 h-4" />
-										</a>
-									</TooltipTrigger>
-									<TooltipContent>Report an issue</TooltipContent>
-								</Tooltip>
+			<PermissionsProvider>
+				<AppSidebar />
+				<div className="w-full relative flex flex-col min-h-screen md:h-screen md:overflow-hidden">
+					<header className="z-50 bg-card-header border-b border-border/80 dark:border-border/50 shrink-0 h-16.25">
+						<div className="flex items-center h-full justify-between px-2 sm:px-8 mx-auto container gap-4">
+							<div className="flex items-center gap-4 min-w-0">
+								<SidebarTrigger />
+								<AppBreadcrumb />
 							</div>
-						)}
+							{loaderData.user && (
+								<div className="flex items-center bg-card dark:bg-muted/30 border border-border/80 dark:border-border/50 px-2 py-1 rounded-full shadow-[0_2px_10px_-4px_rgba(0,0,0,0.05)] dark:shadow-sm">
+									<span className="text-sm text-muted-foreground hidden md:inline-flex pl-2 mr-5">
+										<span className="text-foreground">{loaderData.user.name}</span>
+									</span>
+									<ThemeToggle />
+									<Tooltip>
+										<TooltipTrigger asChild>
+											<Button
+												variant="ghost"
+												size="icon"
+												className="rounded-full h-7 text-xs text-muted-foreground hover:text-foreground"
+												onClick={handleLogout}
+											>
+												<LogOut className="w-4 h-4" />
+											</Button>
+										</TooltipTrigger>
+										<TooltipContent>Logout</TooltipContent>
+									</Tooltip>
+									<Tooltip>
+										<TooltipTrigger asChild>
+											<a
+												href="https://github.com/nicotsx/zerobyte/issues/new/choose"
+												target="_blank"
+												rel="noreferrer"
+												className={buttonVariants({
+													variant: "ghost",
+													size: "icon",
+													className:
+														"relative overflow-hidden hidden lg:inline-flex rounded-full h-7 w-7 text-muted-foreground hover:text-foreground",
+												})}
+											>
+												<LifeBuoy className="w-4 h-4" />
+											</a>
+										</TooltipTrigger>
+										<TooltipContent>Report an issue</TooltipContent>
+									</Tooltip>
+								</div>
+							)}
+						</div>
+					</header>
+					<div className="main-content flex-1 md:overflow-y-auto">
+						<GridBackground>
+							<main className="flex flex-col p-2 pb-6 pt-2 sm:p-8 sm:pt-6 mx-auto">
+								<Outlet />
+							</main>
+						</GridBackground>
 					</div>
-				</header>
-				<div className="main-content flex-1 md:overflow-y-auto">
-					<GridBackground>
-						<main className="flex flex-col p-2 pb-6 pt-2 sm:p-8 sm:pt-6 mx-auto">
-							<Outlet />
-						</main>
-					</GridBackground>
 				</div>
-			</div>
-			<DevPanelListener />
+				<DevPanelListener />
+			</PermissionsProvider>
 		</SidebarProvider>
 	);
 }

--- a/app/client/hooks/use-permissions.tsx
+++ b/app/client/hooks/use-permissions.tsx
@@ -1,0 +1,41 @@
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { useServerFn } from "@tanstack/react-start";
+import { createContext, type ReactNode, useContext, useMemo } from "react";
+import type { Permission, RuntimeFeature } from "~/lib/permission-policy";
+import { getCurrentPermissions, getCurrentPermissionsOptions } from "~/server/lib/functions/current-permissions";
+
+type Permissions = {
+	can: (permission: Permission) => boolean;
+	hasRuntimeFeature: (feature: RuntimeFeature) => boolean;
+};
+
+const PermissionsContext = createContext<Permissions | null>(null);
+
+type Props = {
+	children: ReactNode;
+};
+
+export function PermissionsProvider({ children }: Props) {
+	const getPermissions = useServerFn(getCurrentPermissions);
+	const { data } = useSuspenseQuery(getCurrentPermissionsOptions(getPermissions));
+
+	const permissions = useMemo<Permissions>(
+		() => ({
+			can: (permission) => data.permissions[permission],
+			hasRuntimeFeature: (feature) => data.features[feature],
+		}),
+		[data],
+	);
+
+	return <PermissionsContext.Provider value={permissions}>{children}</PermissionsContext.Provider>;
+}
+
+export function usePermissions() {
+	const permissions = useContext(PermissionsContext);
+
+	if (!permissions) {
+		throw new Error("usePermissions must be used inside PermissionsProvider");
+	}
+
+	return permissions;
+}

--- a/app/client/modules/auth/routes/download-recovery-key.tsx
+++ b/app/client/modules/auth/routes/download-recovery-key.tsx
@@ -20,10 +20,11 @@ const RECOVERY_KEY_CREDENTIAL_REQUIRED_MESSAGE =
 
 type Props = {
 	hasCredentialPassword: boolean;
+	requiresPassword: boolean;
 	userId: string | null;
 };
 
-export function DownloadRecoveryKeyPage({ hasCredentialPassword, userId }: Props) {
+export function DownloadRecoveryKeyPage({ hasCredentialPassword, requiresPassword, userId }: Props) {
 	const navigate = useNavigate();
 	const [password, setPassword] = useState("");
 	const [blockedMessage, setBlockedMessage] = useState<string | null>(null);
@@ -55,13 +56,13 @@ export function DownloadRecoveryKeyPage({ hasCredentialPassword, userId }: Props
 	const handleSubmit = (e: React.SubmitEvent) => {
 		e.preventDefault();
 
-		if (!password) {
+		if (requiresPassword && !password) {
 			toast.error("Password is required");
 			return;
 		}
 
 		setBlockedMessage(null);
-		downloadResticPassword.mutate({ body: { password } });
+		downloadResticPassword.mutate({ body: { password: requiresPassword ? password : "" } });
 	};
 
 	const handleSkip = () => {
@@ -88,7 +89,7 @@ export function DownloadRecoveryKeyPage({ hasCredentialPassword, userId }: Props
 			</Alert>
 
 			<form onSubmit={handleSubmit} className="space-y-4">
-				{(!hasCredentialPassword || blockedMessage) && (
+				{requiresPassword && (!hasCredentialPassword || blockedMessage) && (
 					<Alert variant="warning">
 						<AlertTriangle className="size-5" />
 						<AlertTitle>Local password required</AlertTitle>
@@ -98,7 +99,7 @@ export function DownloadRecoveryKeyPage({ hasCredentialPassword, userId }: Props
 					</Alert>
 				)}
 
-				{hasCredentialPassword && (
+				{requiresPassword && hasCredentialPassword && (
 					<div className="space-y-2">
 						<Label htmlFor="password">Confirm Your Password</Label>
 						<Input
@@ -117,7 +118,7 @@ export function DownloadRecoveryKeyPage({ hasCredentialPassword, userId }: Props
 				)}
 
 				<div className="flex flex-col gap-2">
-					{hasCredentialPassword && (
+					{(!requiresPassword || hasCredentialPassword) && (
 						<Button type="submit" loading={downloadResticPassword.isPending} className="w-full">
 							<Download size={16} className="mr-2" />
 							Download Recovery Key

--- a/app/client/modules/settings/routes/settings.tsx
+++ b/app/client/modules/settings/routes/settings.tsx
@@ -54,6 +54,7 @@ import { OrgMembersSection } from "../components/org-members-section";
 import { PendingInvitationsSection } from "../components/pending-invitations-section";
 import { useOrganizationContext } from "~/client/hooks/use-org-context";
 import { cn } from "~/client/lib/utils";
+import { usePermissions } from "~/client/hooks/use-permissions";
 
 const RECOVERY_KEY_CREDENTIAL_REQUIRED_MESSAGE =
 	"Downloading the recovery key requires a local credential password. Ask an operator to run `docker exec -it zerobyte bun run cli reset-password` for your user, then sign in with that password and try again.";
@@ -81,15 +82,18 @@ export function SettingsPage({
 	const [downloadBlockedMessage, setDownloadBlockedMessage] = useState<string | null>(null);
 	const [isChangingPassword, setIsChangingPassword] = useState(false);
 	const { dateFormat, timeFormat } = useRootLoaderData();
+	const permissions = usePermissions();
 
 	const { tab } = useSearch({ from: "/(dashboard)/settings/" });
-	const activeTab = tab || "account";
 
 	const navigate = useNavigate();
-	const { activeMember, activeOrganization } = useOrganizationContext();
-	const isOrgAdmin = activeMember?.role === "owner" || activeMember?.role === "admin";
+	const { activeOrganization } = useOrganizationContext();
+	const showOrganizationSettings = permissions.can("organizationSettings.view");
+	const activeTab = tab === "organization" && !showOrganizationSettings ? "account" : tab || "account";
 	const { formatDateTime } = useTimeFormat();
 	const hasCredentialPassword = appContext.user?.hasCredentialPassword !== false;
+	const requiresRecoveryKeyPassword = permissions.hasRuntimeFeature("recoveryKeyPasswordRequired");
+	const canDownloadRecoveryKey = !requiresRecoveryKeyPassword || hasCredentialPassword;
 
 	const handleLogout = async () => {
 		await authClient.signOut({
@@ -174,7 +178,7 @@ export function SettingsPage({
 	const handleDownloadResticPassword = (e: React.SubmitEvent) => {
 		e.preventDefault();
 
-		if (!downloadPassword) {
+		if (requiresRecoveryKeyPassword && !downloadPassword) {
 			toast.error("Password is required");
 			return;
 		}
@@ -182,7 +186,7 @@ export function SettingsPage({
 		setDownloadBlockedMessage(null);
 		downloadResticPassword.mutate({
 			body: {
-				password: downloadPassword,
+				password: requiresRecoveryKeyPassword ? downloadPassword : "",
 			},
 		});
 	};
@@ -232,7 +236,7 @@ export function SettingsPage({
 			<Tabs value={activeTab} onValueChange={onTabChange} className="w-full">
 				<TabsList>
 					<TabsTrigger value="account">Account</TabsTrigger>
-					{isOrgAdmin && <TabsTrigger value="organization">Organization</TabsTrigger>}
+					{showOrganizationSettings && <TabsTrigger value="organization">Organization</TabsTrigger>}
 				</TabsList>
 
 				<div className="mt-2">
@@ -419,16 +423,20 @@ export function SettingsPage({
 											<DialogHeader>
 												<DialogTitle>Download Recovery Key</DialogTitle>
 												<DialogDescription>
-													{!hasCredentialPassword
-														? "A local credential password is required before this recovery key can be downloaded."
-														: "For security reasons, please enter your account password to download the recovery key file."}
+													{!requiresRecoveryKeyPassword
+														? "Download the recovery key file and store it somewhere safe."
+														: !hasCredentialPassword
+															? "A local credential password is required before this recovery key can be downloaded."
+															: "For security reasons, please enter your account password to download the recovery key file."}
 												</DialogDescription>
 											</DialogHeader>
 											<div className="space-y-4 py-4">
 												<Alert
 													variant="warning"
 													className={cn({
-														hidden: hasCredentialPassword && !downloadBlockedMessage,
+														hidden:
+															!requiresRecoveryKeyPassword ||
+															(hasCredentialPassword && !downloadBlockedMessage),
 													})}
 												>
 													<AlertTriangle className="size-5" />
@@ -438,7 +446,11 @@ export function SettingsPage({
 															RECOVERY_KEY_CREDENTIAL_REQUIRED_MESSAGE}
 													</AlertDescription>
 												</Alert>
-												<div className={cn("space-y-2", { hidden: !hasCredentialPassword })}>
+												<div
+													className={cn("space-y-2", {
+														hidden: !requiresRecoveryKeyPassword || !hasCredentialPassword,
+													})}
+												>
 													<Label htmlFor="download-password">Your Password</Label>
 													<Input
 														id="download-password"
@@ -446,7 +458,7 @@ export function SettingsPage({
 														value={downloadPassword}
 														onChange={(e) => setDownloadPassword(e.target.value)}
 														placeholder="Enter your password"
-														required
+														required={requiresRecoveryKeyPassword && hasCredentialPassword}
 													/>
 												</div>
 											</div>
@@ -465,7 +477,7 @@ export function SettingsPage({
 												<Button
 													type="submit"
 													loading={downloadResticPassword.isPending}
-													className={cn({ hidden: !hasCredentialPassword })}
+													className={cn({ hidden: !canDownloadRecoveryKey })}
 												>
 													<Download className="h-4 w-4 mr-2" />
 													Download
@@ -484,7 +496,7 @@ export function SettingsPage({
 						</Card>
 					</TabsContent>
 
-					{isOrgAdmin && (
+					{showOrganizationSettings && (
 						<TabsContent value="organization" className="mt-0 space-y-4">
 							<Card className="p-0 gap-0">
 								<div className="border-b border-border/50 bg-card-header p-6">

--- a/app/lib/__tests__/permission-policy.test.ts
+++ b/app/lib/__tests__/permission-policy.test.ts
@@ -1,13 +1,13 @@
 import { describe, expect, test } from "vitest";
-import { allowsPermission, evaluatePermission, hasRuntimeFeature } from "../permission-policy";
+import { evaluatePermission, hasRuntimeFeature } from "../permission-policy";
 
 describe("permissions", () => {
 	test("allows organization settings only for org admins in runtimes that support organization administration", () => {
 		expect(
-			allowsPermission("organizationSettings.view", {
+			evaluatePermission("organizationSettings.view", {
 				runtime: "server",
 				orgRole: "admin",
-			}),
+			}).allowed,
 		).toBe(true);
 
 		expect(
@@ -27,11 +27,11 @@ describe("permissions", () => {
 
 	test("keeps SSO provider creation owner-only and browser-session-only", () => {
 		expect(
-			allowsPermission("ssoProvider.create", {
+			evaluatePermission("ssoProvider.create", {
 				runtime: "server",
 				orgRole: "owner",
 				authSource: "browser-session",
-			}),
+			}).allowed,
 		).toBe(true);
 
 		expect(
@@ -53,11 +53,11 @@ describe("permissions", () => {
 
 	test("requires desktop-sensitive instance administration to pass runtime, role, and auth source", () => {
 		expect(
-			allowsPermission("instanceAdministration.view", {
+			evaluatePermission("instanceAdministration.view", {
 				runtime: "server",
 				instanceRole: "admin",
 				authSource: "browser-session",
-			}),
+			}).allowed,
 		).toBe(true);
 
 		expect(

--- a/app/lib/permission-policy.ts
+++ b/app/lib/permission-policy.ts
@@ -73,6 +73,8 @@ const PERMISSIONS = {
 } as const satisfies Record<string, PermissionPolicy>;
 
 export type Permission = keyof typeof PERMISSIONS;
+export const PERMISSION_KEYS = Object.keys(PERMISSIONS) as Permission[];
+export const RUNTIME_FEATURE_KEYS = Object.keys(RUNTIME_FEATURES.server) as RuntimeFeature[];
 
 export type PermissionContext = {
 	instanceRole?: string | null;
@@ -116,8 +118,4 @@ export function evaluatePermission(permission: Permission, context: PermissionPo
 	}
 
 	return { allowed: true };
-}
-
-export function allowsPermission(permission: Permission, context: PermissionPolicyContext) {
-	return evaluatePermission(permission, context).allowed;
 }

--- a/app/routes/(auth)/download-recovery-key.tsx
+++ b/app/routes/(auth)/download-recovery-key.tsx
@@ -3,6 +3,7 @@ import { createServerFn } from "@tanstack/react-start";
 import { getRequestHeaders } from "@tanstack/react-start/server";
 import { DownloadRecoveryKeyPage } from "~/client/modules/auth/routes/download-recovery-key";
 import { auth } from "~/server/lib/auth";
+import { serverHasRuntimeFeature } from "~/server/lib/permission-service";
 import { userHasCredentialPassword } from "~/server/modules/auth/helpers";
 
 const getRecoveryKeyUserState = createServerFn({ method: "GET" }).handler(async () => {
@@ -11,6 +12,7 @@ const getRecoveryKeyUserState = createServerFn({ method: "GET" }).handler(async 
 
 	return {
 		hasCredentialPassword: session?.user ? await userHasCredentialPassword(session.user.id) : false,
+		requiresPassword: serverHasRuntimeFeature("recoveryKeyPasswordRequired"),
 		userId: session?.user.id ?? null,
 	};
 });
@@ -31,7 +33,13 @@ export const Route = createFileRoute("/(auth)/download-recovery-key")({
 });
 
 function RouteComponent() {
-	const { hasCredentialPassword, userId } = Route.useLoaderData();
+	const { hasCredentialPassword, requiresPassword, userId } = Route.useLoaderData();
 
-	return <DownloadRecoveryKeyPage hasCredentialPassword={hasCredentialPassword} userId={userId} />;
+	return (
+		<DownloadRecoveryKeyPage
+			hasCredentialPassword={hasCredentialPassword}
+			requiresPassword={requiresPassword}
+			userId={userId}
+		/>
+	);
 }

--- a/app/routes/(dashboard)/admin/index.tsx
+++ b/app/routes/(dashboard)/admin/index.tsx
@@ -12,7 +12,7 @@ export const Route = createFileRoute("/(dashboard)/admin/")({
 	loader: async ({ context }) => {
 		const authContext = await fetchUser();
 
-		if (authContext.user?.role !== "admin") {
+		if (!context.permissions["instanceAdministration.view"]) {
 			throw redirect({ to: "/settings" });
 		}
 

--- a/app/routes/(dashboard)/route.tsx
+++ b/app/routes/(dashboard)/route.tsx
@@ -5,6 +5,7 @@ import { Layout } from "~/client/components/layout";
 import { SIDEBAR_COOKIE_NAME } from "~/client/components/ui/sidebar";
 import { authMiddleware } from "~/middleware/auth";
 import { auth } from "~/server/lib/auth";
+import { getCurrentPermissionsOptions } from "~/server/lib/functions/current-permissions";
 import { getOrganizationContext } from "~/server/lib/functions/organization-context";
 import { getServerConstants } from "~/server/lib/functions/server-constants";
 import { userHasCredentialPassword } from "~/server/modules/auth/helpers";
@@ -36,6 +37,7 @@ export const Route = createFileRoute("/(dashboard)")({
 	server: {
 		middleware: [authMiddleware],
 	},
+	beforeLoad: async ({ context }) => context.queryClient.fetchQuery(getCurrentPermissionsOptions()),
 	loader: async ({ context }) => {
 		const [authContext] = await Promise.all([
 			fetchUser(),

--- a/app/routes/(dashboard)/settings/index.tsx
+++ b/app/routes/(dashboard)/settings/index.tsx
@@ -16,16 +16,17 @@ export const Route = createFileRoute("/(dashboard)/settings/")({
 	validateSearch: z.object({ tab: z.string().optional() }),
 	errorComponent: () => <div>Failed to load settings</div>,
 	loader: async ({ context }) => {
-		const [authContext, orgContext, userInvitations] = await Promise.all([
-			fetchUser(),
-			context.queryClient.ensureQueryData({
-				queryKey: ["organization-context"],
-				queryFn: () => getOrganizationContext(),
-			}),
-			context.queryClient.ensureQueryData({ ...getUserSsoInvitationsOptions() }),
-		]);
-		const orgRole = orgContext.activeMember?.role;
-		const shouldPrefetchOrgQueries = orgRole === "owner" || orgRole === "admin";
+		const authContextPromise = fetchUser();
+		const orgContextPromise = context.queryClient.ensureQueryData({
+			queryKey: ["organization-context"],
+			queryFn: () => getOrganizationContext(),
+		});
+		const userInvitationsPromise = context.queryClient.ensureQueryData({ ...getUserSsoInvitationsOptions() });
+
+		const [authContext, userInvitations] = await Promise.all([authContextPromise, userInvitationsPromise]);
+		await orgContextPromise;
+
+		const shouldPrefetchOrgQueries = context.permissions["organizationSettings.view"];
 
 		if (shouldPrefetchOrgQueries) {
 			const [org, members, appOrigin] = await Promise.all([

--- a/app/routes/(dashboard)/settings/sso/new.tsx
+++ b/app/routes/(dashboard)/settings/sso/new.tsx
@@ -1,15 +1,11 @@
 import { createFileRoute, redirect } from "@tanstack/react-router";
 import { CreateSsoProviderPage } from "~/client/modules/sso/routes/create-sso-provider";
-import { getOrganizationContext } from "~/server/lib/functions/organization-context";
 
 export const Route = createFileRoute("/(dashboard)/settings/sso/new")({
 	component: RouteComponent,
 	errorComponent: () => <div>Failed to load SSO registration</div>,
-	loader: async () => {
-		const orgContext = await getOrganizationContext();
-		const role = orgContext.activeMember?.role;
-
-		if (role !== "owner") {
+	loader: async ({ context }) => {
+		if (!context.permissions["ssoProvider.create"]) {
 			throw redirect({ to: "/settings" });
 		}
 	},

--- a/app/server/core/request-context.ts
+++ b/app/server/core/request-context.ts
@@ -1,15 +1,52 @@
 import { AsyncLocalStorage } from "node:async_hooks";
+import {
+	evaluatePermission,
+	hasRuntimeFeature,
+	PERMISSION_KEYS,
+	RUNTIME_FEATURE_KEYS,
+	type Permission,
+	type PermissionContext,
+	type PermissionResult,
+	type RuntimeFeature,
+} from "~/lib/permission-policy";
+import { config } from "./config";
+
+export type PermissionSnapshot = {
+	permissions: Record<Permission, boolean>;
+	features: Record<RuntimeFeature, boolean>;
+	permissionResults: Record<Permission, PermissionResult>;
+};
 
 type RequestContext = {
 	organizationId: string;
 	userId?: string;
-};
+} & Partial<PermissionContext> &
+	Partial<PermissionSnapshot>;
 
 const requestContextStorage = new AsyncLocalStorage<RequestContext>();
 
-export const withContext = <T>(context: RequestContext, fn: () => T): T => {
-	return requestContextStorage.run(context, fn);
-};
+export function withContext<T>(context: RequestContext, fn: () => T): T {
+	const { instanceRole, orgRole, authSource, ...baseContext } = context;
+	const nextContext = { ...baseContext, ...resolvePermissions({ instanceRole, orgRole, authSource }) };
+	return requestContextStorage.run(nextContext, fn);
+}
+
+export function resolvePermissions(context: PermissionContext): PermissionSnapshot {
+	const permissionResults = {} as Record<Permission, PermissionResult>;
+	const permissions = {} as Record<Permission, boolean>;
+	for (const permission of PERMISSION_KEYS) {
+		const result = evaluatePermission(permission, { ...context, runtime: config.runtime });
+		permissionResults[permission] = result;
+		permissions[permission] = result.allowed;
+	}
+
+	const features = {} as Record<RuntimeFeature, boolean>;
+	for (const feature of RUNTIME_FEATURE_KEYS) {
+		features[feature] = hasRuntimeFeature(config.runtime, feature);
+	}
+
+	return { permissions, features, permissionResults };
+}
 
 const getRequestContext = (): RequestContext => {
 	const context = requestContextStorage.getStore();
@@ -22,3 +59,21 @@ const getRequestContext = (): RequestContext => {
 };
 
 export const getOrganizationId = () => getRequestContext().organizationId;
+
+const getPermissionSnapshot = (): PermissionSnapshot => {
+	const context = getRequestContext();
+
+	if (!context.permissions || !context.features || !context.permissionResults) {
+		throw new Error("Permission context is missing");
+	}
+
+	return {
+		permissions: context.permissions,
+		features: context.features,
+		permissionResults: context.permissionResults,
+	};
+};
+
+export const getPermission = (permission: Permission) => getPermissionSnapshot().permissionResults[permission];
+export const can = (permission: Permission) => getPermissionSnapshot().permissions[permission];
+export const hasFeature = (feature: RuntimeFeature) => getPermissionSnapshot().features[feature];

--- a/app/server/lib/functions/current-permissions.ts
+++ b/app/server/lib/functions/current-permissions.ts
@@ -1,0 +1,35 @@
+import { createServerFn } from "@tanstack/react-start";
+import { getRequestHeaders } from "@tanstack/react-start/server";
+import type { Permission, RuntimeFeature } from "~/lib/permission-policy";
+import { resolvePermissions } from "~/server/core/request-context";
+import { auth } from "~/server/lib/auth";
+
+export const currentPermissionsQueryKey = ["current-permissions"] as const;
+
+export type CurrentPermissions = {
+	permissions: Record<Permission, boolean>;
+	features: Record<RuntimeFeature, boolean>;
+};
+
+export function getCurrentPermissionsOptions(
+	queryFn: () => Promise<CurrentPermissions> = () => getCurrentPermissions(),
+) {
+	return { queryKey: currentPermissionsQueryKey, queryFn };
+}
+
+export const getCurrentPermissions = createServerFn({ method: "GET" }).handler(
+	async (): Promise<CurrentPermissions> => {
+		const headers = getRequestHeaders();
+		const [session, activeMember] = await Promise.all([
+			auth.api.getSession({ headers }),
+			auth.api.getActiveMember({ headers }),
+		]);
+		const { permissions, features } = resolvePermissions({
+			instanceRole: session?.user?.role,
+			orgRole: activeMember?.role,
+			authSource: session?.user ? ("browser-session" as const) : null,
+		});
+
+		return { permissions, features };
+	},
+);

--- a/app/server/lib/permission-service.ts
+++ b/app/server/lib/permission-service.ts
@@ -1,17 +1,5 @@
-import {
-	evaluatePermission,
-	hasRuntimeFeature as hasRuntimeFeatureWithRuntime,
-	type Permission,
-	type PermissionContext,
-	type RuntimeFeature,
-} from "~/lib/permission-policy";
+import { hasRuntimeFeature as hasRuntimeFeatureWithRuntime, type RuntimeFeature } from "~/lib/permission-policy";
 import { config } from "~/server/core/config";
-
-export type { Permission, PermissionContext, PermissionResult } from "~/lib/permission-policy";
-
-export function checkPermissionForContext(permission: Permission, context: PermissionContext) {
-	return evaluatePermission(permission, { ...context, runtime: config.runtime });
-}
 
 export function serverHasRuntimeFeature(feature: RuntimeFeature) {
 	return hasRuntimeFeatureWithRuntime(config.runtime, feature);

--- a/app/server/modules/auth/auth.middleware.ts
+++ b/app/server/modules/auth/auth.middleware.ts
@@ -1,9 +1,9 @@
 import { createMiddleware } from "hono/factory";
 import { auth } from "~/server/lib/auth";
 import { db } from "~/server/db/db";
-import { withContext } from "~/server/core/request-context";
+import { getPermission, withContext } from "~/server/core/request-context";
 import { getApiKeyOrganizationId } from "../api-keys/api-keys.service";
-import { checkPermissionForContext, type Permission } from "~/server/lib/permission-service";
+import type { Permission } from "~/lib/permission-policy";
 
 const API_KEY_HEADER = "x-api-key";
 type AuthSource = "browser-session" | "api-key";
@@ -85,9 +85,18 @@ export const requireAuth = createMiddleware(async (c, next) => {
 	c.set("membership", membership);
 	c.set("authSource", authSource);
 
-	await withContext({ organizationId: activeOrganizationId, userId: user.id }, async () => {
-		await next();
-	});
+	await withContext(
+		{
+			organizationId: activeOrganizationId,
+			userId: user.id,
+			instanceRole: user.role,
+			orgRole: membership.role,
+			authSource,
+		},
+		async () => {
+			await next();
+		},
+	);
 });
 
 export const requireBrowserSession = createMiddleware(async (c, next) => {
@@ -100,11 +109,7 @@ export const requireBrowserSession = createMiddleware(async (c, next) => {
 
 export const requirePermission = (permission: Permission) =>
 	createMiddleware(async (c, next) => {
-		const result = checkPermissionForContext(permission, {
-			instanceRole: c.get("user")?.role,
-			orgRole: c.get("membership")?.role,
-			authSource: c.get("authSource"),
-		});
+		const result = getPermission(permission);
 
 		if (result.allowed) {
 			await next();

--- a/app/server/modules/sso/middlewares/authorize-registration.ts
+++ b/app/server/modules/sso/middlewares/authorize-registration.ts
@@ -1,7 +1,7 @@
 import { APIError } from "better-auth/api";
 import type { AuthMiddlewareContext } from "~/server/lib/auth";
 import { db } from "~/server/db/db";
-import { checkPermissionForContext } from "~/server/lib/permission-service";
+import { getPermission, withContext } from "~/server/core/request-context";
 
 export const authorizeSsoRegistration = async (ctx: AuthMiddlewareContext) => {
 	if (ctx.path !== "/sso/register") {
@@ -40,10 +40,15 @@ export const authorizeSsoRegistration = async (ctx: AuthMiddlewareContext) => {
 		throw new APIError("FORBIDDEN", { message: "You are not a member of this organization" });
 	}
 
-	const permission = checkPermissionForContext("ssoProvider.create", {
-		orgRole: membership.role,
-		authSource: "browser-session",
-	});
+	const permission = withContext(
+		{
+			organizationId,
+			userId: session.user.id,
+			orgRole: membership.role,
+			authSource: "browser-session",
+		},
+		() => getPermission("ssoProvider.create"),
+	);
 
 	if (permission.allowed) {
 		return;

--- a/app/server/modules/system/__tests__/system.controller.test.ts
+++ b/app/server/modules/system/__tests__/system.controller.test.ts
@@ -4,7 +4,7 @@ import { createTestSession, createTestSessionWithGlobalAdmin, getAuthHeaders } f
 import { systemService } from "../system.service";
 import * as authHelpers from "~/server/modules/auth/helpers";
 import { db } from "~/server/db/db";
-import { organization } from "~/server/db/schema";
+import { organization, usersTable } from "~/server/db/schema";
 import { eq } from "drizzle-orm";
 import { cryptoUtils } from "~/server/utils/crypto";
 import { config } from "~/server/core/config";
@@ -21,6 +21,7 @@ beforeAll(async () => {
 
 afterEach(() => {
 	config.runtime = "server";
+	vi.restoreAllMocks();
 });
 
 describe("system security", () => {
@@ -181,6 +182,43 @@ describe("system security", () => {
 			expect(res.status).toBe(200);
 			expect(res.headers.get("Content-Type")).toContain("text/plain");
 			expect(await res.text()).toBe(resticPassword);
+		});
+
+		test("should download restic password without password re-authentication in desktop mode", async () => {
+			config.runtime = "desktop";
+			const { cryptoUtils: actualCryptoUtils } =
+				await vi.importActual<typeof import("~/server/utils/crypto")>("~/server/utils/crypto");
+			const resticPassword = "desktop-restic-password";
+			const encryptedResticPassword = await actualCryptoUtils.sealSecret(resticPassword);
+			const verifyPasswordSpy = vi.spyOn(authHelpers, "verifyUserPassword").mockResolvedValueOnce(false);
+
+			await db
+				.update(organization)
+				.set({ metadata: { resticPassword: encryptedResticPassword } })
+				.where(eq(organization.id, session.organizationId));
+			await db
+				.update(usersTable)
+				.set({ hasDownloadedResticPassword: false })
+				.where(eq(usersTable.id, session.user.id));
+			vi.spyOn(cryptoUtils, "resolveSecret").mockImplementationOnce(actualCryptoUtils.resolveSecret);
+
+			const res = await app.request("/api/v1/system/restic-password", {
+				method: "POST",
+				headers: {
+					...session.headers,
+					"Content-Type": "application/json",
+				},
+				body: JSON.stringify({
+					password: "",
+				}),
+			});
+
+			expect(res.status).toBe(200);
+			expect(await res.text()).toBe(resticPassword);
+			expect(verifyPasswordSpy).not.toHaveBeenCalled();
+
+			const updatedUser = await db.query.usersTable.findFirst({ where: { id: session.user.id } });
+			expect(updatedUser?.hasDownloadedResticPassword).toBe(true);
 		});
 
 		test("should return 400 for invalid payload on restic-password", async () => {

--- a/app/server/modules/system/system.controller.ts
+++ b/app/server/modules/system/system.controller.ts
@@ -22,6 +22,7 @@ import { eq } from "drizzle-orm";
 import { verifyUserPassword } from "../auth/helpers";
 import { cryptoUtils } from "../../utils/crypto";
 import { getOrganizationId } from "~/server/core/request-context";
+import { serverHasRuntimeFeature } from "~/server/lib/permission-service";
 
 export const systemController = new Hono()
 	.use(requireAuth)
@@ -63,10 +64,13 @@ export const systemController = new Hono()
 			const user = c.get("user");
 			const organizationId = getOrganizationId();
 			const body = c.req.valid("json");
+			const requiresPassword = serverHasRuntimeFeature("recoveryKeyPasswordRequired");
 
-			const isPasswordValid = await verifyUserPassword({ password: body.password, userId: user.id });
-			if (!isPasswordValid) {
-				return c.json({ message: "Invalid password" }, 401);
+			if (requiresPassword) {
+				const isPasswordValid = await verifyUserPassword({ password: body.password, userId: user.id });
+				if (!isPasswordValid) {
+					return c.json({ message: "Invalid password" }, 401);
+				}
 			}
 
 			try {


### PR DESCRIPTION
Use the new permissions capabilities to hide stuff from the desktop
runtime

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Migrated from role-based to permission-based access control for features
  * Updated recovery key download with optional password verification requirement

<!-- end of auto-generated comment: release notes by coderabbit.ai -->