### PR TITLE
feat(repositories): add S3 storage class support

### DIFF
--- a/app/client/modules/repositories/components/repository-forms/s3-repository-form.tsx
+++ b/app/client/modules/repositories/components/repository-forms/s3-repository-form.tsx
@@ -48,6 +48,22 @@ export const S3RepositoryForm = ({ form }: Props) => {
 			/>
 			<FormField
 				control={form.control}
+				name="storageClass"
+				render={({ field }) => (
+					<FormItem>
+						<FormLabel>Storage class (optional)</FormLabel>
+						<FormControl>
+							<Input placeholder="STANDARD_IA" {...field} />
+						</FormControl>
+						<FormDescription>
+							Passed to restic as <code>s3.storage-class</code>. Use a class supported by your provider.
+						</FormDescription>
+						<FormMessage />
+					</FormItem>
+				)}
+			/>
+			<FormField
+				control={form.control}
 				name="accessKeyId"
 				render={({ field }) => (
 					<FormItem>

--- a/app/client/modules/repositories/tabs/info.tsx
+++ b/app/client/modules/repositories/tabs/info.tsx
@@ -37,6 +37,7 @@ export const RepositoryInfoTabContent = ({ repository, initialStats }: Props) =>
 
 	const config = repository.config as RepositoryConfig;
 	const hasLocalPath = Boolean(effectiveLocalPath);
+	const hasStorageClass = Boolean(config.storageClass);
 	const hasCaCert = Boolean(config.cacert);
 	const hasInsecureTlsConfig = config.insecureTls !== undefined;
 
@@ -95,6 +96,7 @@ export const RepositoryInfoTabContent = ({ repository, initialStats }: Props) =>
 					{hasLocalPath && (
 						<ConfigRow icon={<FolderOpen className="h-4 w-4" />} label="Local Path" value={effectiveLocalPath!} mono />
 					)}
+					{hasStorageClass && <ConfigRow icon={<Archive className="h-4 w-4" />} label="Storage Class" value={config.storageClass!} mono />}
 					<ConfigRow
 						icon={<Archive className="h-4 w-4" />}
 						label="Compression Mode"

--- a/packages/core/src/restic/commands/__tests__/copy.test.ts
+++ b/packages/core/src/restic/commands/__tests__/copy.test.ts
@@ -96,6 +96,31 @@ describe("copy command", () => {
 		expect(getArgs()).not.toContain("--ignore-inode");
 	});
 
+	test("passes storage class option for S3 repositories", async () => {
+		const { getArgs } = setup();
+
+		await Effect.runPromise(
+			copy(
+				sourceConfig,
+				{
+					backend: "s3",
+					endpoint: "https://s3.example.com",
+					bucket: "backups",
+					accessKeyId: "ak",
+					secretAccessKey: "sk",
+					storageClass: "STANDARD_IA",
+					isExistingRepository: true,
+					customPassword: "dest-password",
+				},
+				{ organizationId: "org-1", tag: "daily" },
+				mockDeps,
+			),
+		);
+
+		expect(getArgs()).toContain("-o");
+		expect(getArgs()).toContain("s3.storage-class=STANDARD_IA");
+	});
+
 	test("passes multiple snapshot IDs after separator", async () => {
 		const { getArgs } = setup();
 

--- a/packages/core/src/restic/helpers/add-common-args.ts
+++ b/packages/core/src/restic/helpers/add-common-args.ts
@@ -16,6 +16,10 @@ export const addCommonArgs = (
 		args.push("-o", `sftp.args=${env._SFTP_SSH_ARGS}`);
 	}
 
+	if (config?.backend === "s3" && config.storageClass) {
+		args.push("-o", `s3.storage-class=${config.storageClass}`);
+	}
+
 	if (env.AWS_S3_BUCKET_LOOKUP === "dns") {
 		args.push("-o", "s3.bucket-lookup=dns");
 	}

--- a/packages/core/src/restic/schemas.ts
+++ b/packages/core/src/restic/schemas.ts
@@ -45,6 +45,7 @@ export const s3RepositoryConfigSchema = z
 		backend: z.literal("s3"),
 		endpoint: z.string().min(1),
 		bucket: z.string().min(1),
+		storageClass: z.string().min(1).optional(),
 		accessKeyId: z.string().min(1),
 		secretAccessKey: z.string().min(1),
 	})


### PR DESCRIPTION
Hi! Thanks for the great project.

This is my attempt to address #724 as I needed S3 storage class support myself as a mirror.
I have successfully tested the creation of the new repository with GLACIER (pointing to french Scaleway S3 Object Storage), set this to mirror my main backup and triggered a new backup.

I'd really appreciate a review.

Screenshots:
<img width="604" height="205" alt="Screenshot 2026-06-28 at 10 12 25" src="https://github.com/user-attachments/assets/e7ebbb38-c253-4932-8871-d106ee62c0d2" />
<img width="602" height="249" alt="Screenshot 2026-06-28 at 10 11 10" src="https://github.com/user-attachments/assets/ffecbd7d-a5d8-4b9c-911e-ca2cfba916db" />