### PR TITLE
feat(sftp): add option for absolute & parent symlink backups

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -88,6 +88,7 @@ COPY ./packages/core/package.json ./packages/core/package.json
 COPY ./packages/contracts/package.json ./packages/contracts/package.json
 COPY ./apps/agent/package.json ./apps/agent/package.json
 COPY ./apps/docs/package.json ./apps/docs/package.json
+COPY ./apps/desktop/package.json ./apps/desktop/package.json
 
 RUN VITE_GIT_HOOKS=0 bun install --frozen-lockfile --ignore-scripts
 
@@ -113,6 +114,7 @@ COPY ./packages/core/package.json ./packages/core/package.json
 COPY ./packages/contracts/package.json ./packages/contracts/package.json
 COPY ./apps/agent/package.json ./apps/agent/package.json
 COPY ./apps/docs/package.json ./apps/docs/package.json
+COPY ./apps/desktop/package.json ./apps/desktop/package.json
 
 RUN VITE_GIT_HOOKS=0 bun install --frozen-lockfile
 

--- a/app/client/api-client/types.gen.ts
+++ b/app/client/api-client/types.gen.ts
@@ -534,6 +534,7 @@ export type ListVolumesResponses = {
             skipHostKeyCheck?: boolean;
             knownHosts?: string;
             allowLegacySshRsa?: boolean;
+            allowUnsafeSymlinkTargets?: boolean;
         };
         createdAt: number;
         updatedAt: number;
@@ -600,6 +601,7 @@ export type CreateVolumeData = {
             skipHostKeyCheck?: boolean;
             knownHosts?: string;
             allowLegacySshRsa?: boolean;
+            allowUnsafeSymlinkTargets?: boolean;
         };
     };
     path?: never;
@@ -664,6 +666,7 @@ export type CreateVolumeResponses = {
             skipHostKeyCheck?: boolean;
             knownHosts?: string;
             allowLegacySshRsa?: boolean;
+            allowUnsafeSymlinkTargets?: boolean;
         };
         createdAt: number;
         updatedAt: number;
@@ -729,6 +732,7 @@ export type TestConnectionData = {
             skipHostKeyCheck?: boolean;
             knownHosts?: string;
             allowLegacySshRsa?: boolean;
+            allowUnsafeSymlinkTargets?: boolean;
         };
     };
     path?: never;
@@ -842,6 +846,7 @@ export type GetVolumeResponses = {
                 skipHostKeyCheck?: boolean;
                 knownHosts?: string;
                 allowLegacySshRsa?: boolean;
+                allowUnsafeSymlinkTargets?: boolean;
             };
             createdAt: number;
             updatedAt: number;
@@ -915,6 +920,7 @@ export type UpdateVolumeData = {
             skipHostKeyCheck?: boolean;
             knownHosts?: string;
             allowLegacySshRsa?: boolean;
+            allowUnsafeSymlinkTargets?: boolean;
         };
     };
     path: {
@@ -988,6 +994,7 @@ export type UpdateVolumeResponses = {
             skipHostKeyCheck?: boolean;
             knownHosts?: string;
             allowLegacySshRsa?: boolean;
+            allowUnsafeSymlinkTargets?: boolean;
         };
         createdAt: number;
         updatedAt: number;
@@ -2674,6 +2681,7 @@ export type ListBackupSchedulesResponses = {
                 skipHostKeyCheck?: boolean;
                 knownHosts?: string;
                 allowLegacySshRsa?: boolean;
+                allowUnsafeSymlinkTargets?: boolean;
             };
             createdAt: number;
             updatedAt: number;
@@ -3101,6 +3109,7 @@ export type GetBackupScheduleResponses = {
                 skipHostKeyCheck?: boolean;
                 knownHosts?: string;
                 allowLegacySshRsa?: boolean;
+                allowUnsafeSymlinkTargets?: boolean;
             };
             createdAt: number;
             updatedAt: number;
@@ -3509,6 +3518,7 @@ export type GetBackupScheduleForVolumeResponses = {
                 skipHostKeyCheck?: boolean;
                 knownHosts?: string;
                 allowLegacySshRsa?: boolean;
+                allowUnsafeSymlinkTargets?: boolean;
             };
             createdAt: number;
             updatedAt: number;

--- a/app/client/modules/volumes/components/create-volume-form.tsx
+++ b/app/client/modules/volumes/components/create-volume-form.tsx
@@ -49,6 +49,17 @@ export const formSchema = z
 				path: ["knownHosts"],
 			});
 		}
+		if (
+			value.backend === "sftp" &&
+			value.allowUnsafeSymlinkTargets &&
+			(value.skipHostKeyCheck || !value.knownHosts?.trim())
+		) {
+			ctx.addIssue({
+				code: "custom",
+				message: "Unsafe symlink targets require host key verification with known hosts",
+				path: ["allowUnsafeSymlinkTargets"],
+			});
+		}
 	});
 
 export type FormValues = z.input<typeof formSchema>;

--- a/app/client/modules/volumes/components/create-volume-form.tsx
+++ b/app/client/modules/volumes/components/create-volume-form.tsx
@@ -69,7 +69,14 @@ const defaultValuesForType = {
 	smb: { backend: "smb" as const, port: 445, vers: "3.0" as const, mapToContainerUidGid: false },
 	webdav: { backend: "webdav" as const, port: 80, ssl: false, path: "/webdav" },
 	rclone: { backend: "rclone" as const, path: "/" },
-	sftp: { backend: "sftp" as const, port: 22, path: "/", skipHostKeyCheck: false, allowLegacySshRsa: false },
+	sftp: {
+		backend: "sftp" as const,
+		port: 22,
+		path: "/",
+		skipHostKeyCheck: false,
+		allowLegacySshRsa: false,
+		allowUnsafeSymlinkTargets: false,
+	},
 };
 
 export const CreateVolumeForm = ({ onSubmit, mode = "create", initialValues, formId, loading, className }: Props) => {

--- a/app/client/modules/volumes/components/volume-forms/sftp-form.tsx
+++ b/app/client/modules/volumes/components/volume-forms/sftp-form.tsx
@@ -165,7 +165,7 @@ export const SFTPForm = ({ form }: Props) => {
 			)}
 			<Collapsible>
 				<CollapsibleTrigger>Advanced Settings</CollapsibleTrigger>
-				<CollapsibleContent className="pb-4 pt-4">
+				<CollapsibleContent className="pb-4 pt-4 space-y-4">
 					<FormField
 						control={form.control}
 						name="allowLegacySshRsa"
@@ -176,6 +176,25 @@ export const SFTPForm = ({ form }: Props) => {
 									<FormDescription>
 										Only enable this for legacy SFTP servers that offer <code>ssh-rsa</code> only.
 										It permits RSA/SHA1 signatures, which are weaker than modern SSH algorithms.
+									</FormDescription>
+								</div>
+								<FormControl>
+									<Switch checked={field.value ?? false} onCheckedChange={field.onChange} />
+								</FormControl>
+							</FormItem>
+						)}
+					/>
+					<FormField
+						control={form.control}
+						name="allowUnsafeSymlinkTargets"
+						render={({ field }) => (
+							<FormItem className="flex flex-row items-center justify-between rounded-lg border p-3 shadow-sm">
+								<div className="space-y-0.5">
+									<FormLabel>Allow absolute and parent-directory symlinks</FormLabel>
+									<FormDescription>
+										Only enable this for trusted SFTP servers. It disables SSHFS symlink containment
+										so Restic can archive symlinks with absolute targets or <code>..</code> path
+										components.
 									</FormDescription>
 								</div>
 								<FormControl>

--- a/app/client/modules/volumes/components/volume-forms/sftp-form.tsx
+++ b/app/client/modules/volumes/components/volume-forms/sftp-form.tsx
@@ -20,6 +20,7 @@ type Props = {
 
 export const SFTPForm = ({ form }: Props) => {
 	const skipHostKeyCheck = useWatch({ control: form.control, name: "skipHostKeyCheck" });
+	const unsafeSymlinkTargetsDisabled = Boolean(skipHostKeyCheck);
 
 	return (
 		<>
@@ -134,7 +135,18 @@ export const SFTPForm = ({ form }: Props) => {
 							</FormDescription>
 						</div>
 						<FormControl>
-							<Switch checked={field.value} onCheckedChange={field.onChange} />
+							<Switch
+								checked={field.value}
+								onCheckedChange={(checked) => {
+									field.onChange(checked);
+									if (checked) {
+										form.setValue("allowUnsafeSymlinkTargets", false, {
+											shouldDirty: true,
+											shouldValidate: true,
+										});
+									}
+								}}
+							/>
 						</FormControl>
 					</FormItem>
 				)}
@@ -192,14 +204,19 @@ export const SFTPForm = ({ form }: Props) => {
 								<div className="space-y-0.5">
 									<FormLabel>Allow absolute and parent-directory symlinks</FormLabel>
 									<FormDescription>
-										Only enable this for trusted SFTP servers. It disables SSHFS symlink containment
-										so Restic can archive symlinks with absolute targets or <code>..</code> path
-										components.
+										Only enable this for trusted SFTP servers with host key verification and known
+										hosts configured. It disables SSHFS symlink containment so Restic can archive
+										symlinks with absolute targets or <code>..</code> path components.
 									</FormDescription>
 								</div>
 								<FormControl>
-									<Switch checked={field.value ?? false} onCheckedChange={field.onChange} />
+									<Switch
+										checked={field.value ?? false}
+										onCheckedChange={field.onChange}
+										disabled={unsafeSymlinkTargetsDisabled}
+									/>
 								</FormControl>
+								<FormMessage />
 							</FormItem>
 						)}
 					/>

--- a/app/server/modules/backups/__tests__/backups.service.execution.test.ts
+++ b/app/server/modules/backups/__tests__/backups.service.execution.test.ts
@@ -421,6 +421,7 @@ describe("backup execution - validation failures", () => {
 				path: "/data",
 				skipHostKeyCheck: false,
 				allowLegacySshRsa: false,
+				allowUnsafeSymlinkTargets: false,
 			},
 		});
 		const repository = await createTestRepository();

--- a/app/server/modules/volumes/__tests__/volume-config.test.ts
+++ b/app/server/modules/volumes/__tests__/volume-config.test.ts
@@ -1,0 +1,58 @@
+import { volumeConfigSchema } from "@zerobyte/contracts/volumes";
+import { describe, expect, test } from "vitest";
+
+const baseSftpConfig = {
+	backend: "sftp" as const,
+	host: "backup.example.com",
+	port: 22,
+	username: "backup",
+	password: "password",
+	path: "/backups",
+	readOnly: true,
+	skipHostKeyCheck: false,
+	knownHosts: "backup.example.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAITest",
+	allowLegacySshRsa: false,
+	allowUnsafeSymlinkTargets: false,
+};
+
+describe("volumeConfigSchema", () => {
+	test("allows unsafe SFTP symlink targets with verified known hosts", () => {
+		const result = volumeConfigSchema.safeParse({
+			...baseSftpConfig,
+			allowUnsafeSymlinkTargets: true,
+		});
+
+		expect(result.success).toBe(true);
+	});
+
+	test("rejects unsafe SFTP symlink targets when host key checking is skipped", () => {
+		const result = volumeConfigSchema.safeParse({
+			...baseSftpConfig,
+			skipHostKeyCheck: true,
+			allowUnsafeSymlinkTargets: true,
+		});
+
+		expect(result.success).toBe(false);
+	});
+
+	test("rejects unsafe SFTP symlink targets without known hosts", () => {
+		const result = volumeConfigSchema.safeParse({
+			...baseSftpConfig,
+			knownHosts: undefined,
+			allowUnsafeSymlinkTargets: true,
+		});
+
+		expect(result.success).toBe(false);
+	});
+
+	test("keeps skip host key check valid when unsafe symlink targets are disabled", () => {
+		const result = volumeConfigSchema.safeParse({
+			...baseSftpConfig,
+			skipHostKeyCheck: true,
+			knownHosts: undefined,
+			allowUnsafeSymlinkTargets: false,
+		});
+
+		expect(result.success).toBe(true);
+	});
+});

--- a/app/test/integration/infra/sftp/entrypoint.sh
+++ b/app/test/integration/infra/sftp/entrypoint.sh
@@ -21,9 +21,11 @@ install -d -o "$SFTP_USER" -g "$SFTP_USER" -m 0700 "/home/$SFTP_USER/.ssh"
 install -o "$SFTP_USER" -g "$SFTP_USER" -m 0600 "$SFTP_PUBLIC_KEY_PATH" "/home/$SFTP_USER/.ssh/authorized_keys"
 
 install -d -o "$SFTP_USER" -g "$SFTP_USER" -m 0755 "$SERVICE_ROOT/fixtures/case-a/docs"
+install -d -o "$SFTP_USER" -g "$SFTP_USER" -m 0755 "$SERVICE_ROOT/fixtures/absolute-symlink-case"
 install -d -o "$SFTP_USER" -g "$SFTP_USER" -m 0755 "$SERVICE_ROOT/repos/sftp"
 printf 'hello from zerobyte integration\n' >"$SERVICE_ROOT/fixtures/case-a/hello.txt"
 printf 'fixture documentation\n' >"$SERVICE_ROOT/fixtures/case-a/docs/readme.md"
+ln -s "$SERVICE_ROOT/fixtures/case-a/hello.txt" "$SERVICE_ROOT/fixtures/absolute-symlink-case/absolute-hello-link"
 chown -R "$SFTP_USER:$SFTP_USER" "$SERVICE_ROOT"
 
 if [ "$SFTP_LEGACY_RSA_HOSTKEY" = "true" ]; then

--- a/app/test/integration/src/helpers/sftp.ts
+++ b/app/test/integration/src/helpers/sftp.ts
@@ -55,6 +55,7 @@ export const buildSftpPrivateKeyVolumeConfig = ({
 	skipHostKeyCheck: false,
 	knownHosts,
 	allowLegacySshRsa: false,
+	allowUnsafeSymlinkTargets: false,
 });
 
 export const buildSftpPasswordVolumeConfig = ({ knownHosts }: { knownHosts: string }): BackendConfig => ({
@@ -68,6 +69,7 @@ export const buildSftpPasswordVolumeConfig = ({ knownHosts }: { knownHosts: stri
 	skipHostKeyCheck: false,
 	knownHosts,
 	allowLegacySshRsa: false,
+	allowUnsafeSymlinkTargets: false,
 });
 
 export const buildLegacyRsaSftpPasswordVolumeConfig = ({ knownHosts }: { knownHosts: string }): BackendConfig => ({
@@ -81,6 +83,7 @@ export const buildLegacyRsaSftpPasswordVolumeConfig = ({ knownHosts }: { knownHo
 	skipHostKeyCheck: false,
 	knownHosts,
 	allowLegacySshRsa: true,
+	allowUnsafeSymlinkTargets: false,
 });
 
 export const buildSftpRepositoryConfig = ({

--- a/app/test/integration/src/volume-backends.test.ts
+++ b/app/test/integration/src/volume-backends.test.ts
@@ -21,6 +21,7 @@ import {
 	readSftpPrivateKey,
 	scanSftpKnownHosts,
 	SFTP_LEGACY_RSA_HOST,
+	SFTP_FIXTURE_ROOT,
 } from "./helpers/sftp";
 import { buildSmbVolumeConfig } from "./helpers/smb";
 import { buildWebdavVolumeConfig } from "./helpers/webdav";
@@ -207,5 +208,98 @@ volumeMountTest.concurrent.each(scenarios)("$name can backup and restore static 
 
 	if (cleanupError) {
 		throw cleanupError;
+	}
+});
+
+volumeMountTest("SFTP volume can backup absolute symlinks when unsafe targets are allowed", async () => {
+	const runId = crypto.randomUUID();
+	const workspace = path.join(INTEGRATION_RUNS_DIR, `sftp-absolute-symlink-${runId}`);
+	const mountPath = path.join(workspace, "mount");
+	const repositoryPath = path.join(workspace, "repo");
+	const backupTag = `zerobyte-integration-sftp-absolute-symlink-${runId}`;
+	const resticPassword = `zerobyte-integration-sftp-absolute-symlink-${runId}-${crypto.randomBytes(16).toString("hex")}`;
+	const repositoryConfig: RepositoryConfig = { backend: "local", path: repositoryPath };
+	const restic = createIntegrationRestic(workspace, resticPassword);
+	const fixture = {
+		sourceRoot: path.join(mountPath, "absolute-symlink-case"),
+		entries: [
+			{
+				type: "symlink" as const,
+				relativePath: "absolute-hello-link",
+				target: `${SFTP_FIXTURE_ROOT}/case-a/hello.txt`,
+			},
+		],
+	};
+
+	let backend: VolumeBackend | undefined;
+	let passed = false;
+
+	try {
+		await fs.mkdir(workspace, { recursive: true });
+
+		const initResult = await Effect.runPromise(
+			restic.init(repositoryConfig, {
+				organizationId: INTEGRATION_ORGANIZATION_ID,
+				timeoutMs: 120_000,
+			}),
+		);
+		expect(initResult.success).toBe(true);
+		expect(initResult.error).toBeNull();
+
+		const knownHosts = await scanSftpKnownHosts();
+		const privateKey = await readSftpPrivateKey();
+		const config = {
+			...buildSftpPrivateKeyVolumeConfig({ privateKey, knownHosts }),
+			allowUnsafeSymlinkTargets: true,
+		};
+		backend = makeSftpBackend(config, mountPath);
+
+		const mountResult = await backend.mount();
+		expect(mountResult.status).toBe("mounted");
+		await assertFixtureSourceExists(fixture);
+
+		const backupResult = await Effect.runPromise(
+			restic.backup(repositoryConfig, fixture.sourceRoot, {
+				organizationId: INTEGRATION_ORGANIZATION_ID,
+				tags: [backupTag],
+			}),
+		);
+
+		expect(backupResult.exitCode).toBe(0);
+		expect(backupResult.warningDetails).toBeNull();
+		expect(backupResult.result?.snapshot_id).toEqual(expect.any(String));
+
+		const snapshotId = backupResult.result?.snapshot_id;
+		if (!snapshotId) {
+			throw new Error("Restic backup completed without a snapshot id");
+		}
+
+		const lsResult = await Effect.runPromise(
+			restic.ls(repositoryConfig, snapshotId, undefined, {
+				organizationId: INTEGRATION_ORGANIZATION_ID,
+				limit: 100,
+			}),
+		);
+		assertSnapshotContainsFixture(fixture.sourceRoot, lsResult.nodes, fixture);
+
+		const unmountResult = await backend.unmount();
+		expect(unmountResult.status).toBe("unmounted");
+		backend = undefined;
+
+		passed = true;
+	} finally {
+		if (backend) {
+			const unmountResult = await backend.unmount();
+			if (unmountResult.status === "error") {
+				console.error(`Failed to unmount SFTP volume at ${mountPath}: ${unmountResult.error}`);
+			}
+		}
+
+		if (passed) {
+			await makeDirectoriesWritable(workspace);
+			await fs.rm(workspace, { recursive: true, force: true });
+		} else {
+			console.error(`Integration scenario artifacts retained in ${workspace}`);
+		}
 	}
 });

--- a/apps/agent/src/volume-host/backends/sftp.test.ts
+++ b/apps/agent/src/volume-host/backends/sftp.test.ts
@@ -1,0 +1,49 @@
+import type { BackendConfig } from "@zerobyte/contracts/volumes";
+import { expect, test } from "vitest";
+import { makeSftpBackend } from "./sftp";
+
+const baseSftpConfig: BackendConfig = {
+	backend: "sftp",
+	host: "backup.example.com",
+	port: 22,
+	username: "backup",
+	password: "password",
+	path: "/backups",
+	readOnly: true,
+	skipHostKeyCheck: false,
+	knownHosts: "backup.example.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAITest",
+	allowLegacySshRsa: false,
+	allowUnsafeSymlinkTargets: false,
+};
+
+test("rejects unsafe symlink targets when host key checking is skipped", async () => {
+	const backend = makeSftpBackend(
+		{
+			...baseSftpConfig,
+			skipHostKeyCheck: true,
+			allowUnsafeSymlinkTargets: true,
+		},
+		"/tmp/zerobyte-sftp-test",
+	);
+
+	await expect(backend.mount()).resolves.toEqual({
+		status: "error",
+		error: "Unsafe symlink targets require host key verification with known hosts",
+	});
+});
+
+test("rejects unsafe symlink targets without known hosts", async () => {
+	const backend = makeSftpBackend(
+		{
+			...baseSftpConfig,
+			knownHosts: undefined,
+			allowUnsafeSymlinkTargets: true,
+		},
+		"/tmp/zerobyte-sftp-test",
+	);
+
+	await expect(backend.mount()).resolves.toEqual({
+		status: "error",
+		error: "Unsafe symlink targets require host key verification with known hosts",
+	});
+});

--- a/apps/agent/src/volume-host/backends/sftp.ts
+++ b/apps/agent/src/volume-host/backends/sftp.ts
@@ -116,6 +116,14 @@ const mount = async (config: BackendConfig, mountPath: string) => {
 		return { status: "error" as const, error: "Provided config is not for SFTP backend" };
 	}
 
+	if (config.allowUnsafeSymlinkTargets && (config.skipHostKeyCheck || !config.knownHosts?.trim())) {
+		logger.error("Unsafe SFTP symlink targets require host key verification with known hosts.");
+		return {
+			status: "error" as const,
+			error: "Unsafe symlink targets require host key verification with known hosts",
+		};
+	}
+
 	if (os.platform() !== "linux") {
 		logger.error("SFTP mounting is only supported on Linux hosts.");
 		return { status: "error" as const, error: "SFTP mounting is only supported on Linux hosts." };

--- a/apps/agent/src/volume-host/backends/sftp.ts
+++ b/apps/agent/src/volume-host/backends/sftp.ts
@@ -142,6 +142,10 @@ const mount = async (config: BackendConfig, mountPath: string) => {
 			`gid=${gid}`,
 		];
 
+		if (config.allowUnsafeSymlinkTargets) {
+			options.push("no_contain_symlinks");
+		}
+
 		if (config.allowLegacySshRsa) {
 			options.push("ssh_command=ssh -oHostKeyAlgorithms=+ssh-rsa -oPubkeyAcceptedAlgorithms=+ssh-rsa");
 		}

--- a/packages/contracts/src/volumes.ts
+++ b/packages/contracts/src/volumes.ts
@@ -89,14 +89,28 @@ export const sftpConfigSchema = z.object({
 	allowUnsafeSymlinkTargets: z.boolean().default(false),
 });
 
-export const volumeConfigSchema = z.discriminatedUnion("backend", [
-	nfsConfigSchema,
-	smbConfigSchema,
-	webdavConfigSchema,
-	directoryConfigSchema,
-	rcloneConfigSchema,
-	sftpConfigSchema,
-]);
+export const volumeConfigSchema = z
+	.discriminatedUnion("backend", [
+		nfsConfigSchema,
+		smbConfigSchema,
+		webdavConfigSchema,
+		directoryConfigSchema,
+		rcloneConfigSchema,
+		sftpConfigSchema,
+	])
+	.superRefine((value, ctx) => {
+		if (
+			value.backend === "sftp" &&
+			value.allowUnsafeSymlinkTargets &&
+			(value.skipHostKeyCheck || !value.knownHosts?.trim())
+		) {
+			ctx.addIssue({
+				code: "custom",
+				message: "Unsafe symlink targets require host key verification with known hosts",
+				path: ["allowUnsafeSymlinkTargets"],
+			});
+		}
+	});
 
 export type BackendConfig = z.infer<typeof volumeConfigSchema>;
 

--- a/packages/contracts/src/volumes.ts
+++ b/packages/contracts/src/volumes.ts
@@ -86,6 +86,7 @@ export const sftpConfigSchema = z.object({
 	skipHostKeyCheck: z.boolean().default(false),
 	knownHosts: z.string().optional(),
 	allowLegacySshRsa: z.boolean().default(false),
+	allowUnsafeSymlinkTargets: z.boolean().default(false),
 });
 
 export const volumeConfigSchema = z.discriminatedUnion("backend", [


### PR DESCRIPTION
Related issue: #1007

Recent SSHFS now contains absolute/parent-directory symlinks by default, which is safer for browsing but prevents Restic from archiving the original symlink metadata. This adds an opt-in `no_contain_symlinks` switch for trusted SFTP sources that need exact symlink backup