### PR TITLE
Fix Docker build failures by removing outdated Alpine package version pins

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -149,4 +149,4 @@ COPY ./LICENSE ./LICENSE.md
 
 EXPOSE 4096
 
-CMD ["bun", ".output/server/index.mjs"]
+CMD ["/usr/local/bin/bun", ".output/server/index.mjs"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN apk add --no-cache \
 	openssh-client-default=10.0_p1-r10 \
 	sshfs=3.7.6-r0 \
 	tini=0.19.0-r3 \
-	tzdata=2026c-r0
+	tzdata
 
 ENTRYPOINT ["/sbin/tini", "-s", "--"]
 
@@ -39,7 +39,7 @@ ENV TARGETARCH=${TARGETARCH}
 
 RUN apk add --no-cache \
 	bzip2=1.0.8-r6 \
-	curl=8.14.1-r2 \
+	curl \
 	tar=1.35-r3 \
 	unzip=6.0-r15
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN apk add --no-cache \
 	openssh-client-default=10.0_p1-r10 \
 	sshfs=3.7.6-r0 \
 	tini=0.19.0-r3 \
-	tzdata=2026b-r0
+	tzdata=2026c-r0
 
 ENTRYPOINT ["/sbin/tini", "-s", "--"]
 


### PR DESCRIPTION
## Summary

Fix for the Docker build failure caused by outdated Alpine package version pins. `tzdata` and `curl` have been updated in the Alpine repository, causing the build to fail with dependency resolution errors.

## Problem

When following the official docker-compose setup instructions, the container fails to start with the error below and then immediately exits:

```
zerobyte  | [FATAL tini (7)] exec bun failed: No such file or directory
```

This is a downstrem effect, though. Investigating it further by building the Zerobyte container directly from the source, I got errors during the `apk add` step for `tzdata` first, and then for `curl`:

### `tzdata`

```
 > [base 2/2] RUN apk add --no-cache    acl=2.3.2-r1    attr=2.5.2-r2   cifs-utils=7.3-r0       davfs2=1.6.1-r2         fuse3=3.16.2-r1      libcrypto3=3.5.7-r0     libssl3=3.5.7-r0        openssh-client-default=10.0_p1-r10      sshfs=3.7.6-r0  tini=0.19.0-r3  tzdata=2026b-r0:                                                                                                                          
0.432 fetch https://dl-cdn.alpinelinux.org/alpine/v3.22/main/x86_64/APKINDEX.tar.gz                                                  
0.855 fetch https://dl-cdn.alpinelinux.org/alpine/v3.22/community/x86_64/APKINDEX.tar.gz
1.948 ERROR: unable to select packages:
1.953   tzdata-2026c-r0:
1.953     breaks: world[tzdata=2026b-r0]
------
[+] up 0/1
 ⠙ Image zerobyte-zerobyte Building                                                                                              9.0s
Dockerfile:14

--------------------

  13 |     

  14 | >>> RUN apk add --no-cache \

  15 | >>> 	acl=2.3.2-r1 \

  16 | >>> 	attr=2.5.2-r2 \

  17 | >>> 	cifs-utils=7.3-r0 \

  18 | >>> 	davfs2=1.6.1-r2 \

  19 | >>> 	fuse3=3.16.2-r1 \

  20 | >>> 	libcrypto3=3.5.7-r0 \

  21 | >>> 	libssl3=3.5.7-r0 \

  22 | >>> 	openssh-client-default=10.0_p1-r10 \

  23 | >>> 	sshfs=3.7.6-r0 \

  24 | >>> 	tini=0.19.0-r3 \

  25 | >>> 	tzdata=2026b-r0

  26 |     

--------------------

failed to solve: process "/bin/sh -c apk add --no-cache \tacl=2.3.2-r1 \tattr=2.5.2-r2 \tcifs-utils=7.3-r0 \tdavfs2=1.6.1-r2 \tfuse3=3.16.2-r1 \tlibcrypto3=3.5.7-r0 \tlibssl3=3.5.7-r0 \topenssh-client-default=10.0_p1-r10 \tsshfs=3.7.6-r0 \ttini=0.19.0-r3 \ttzdata=2026b-r0" did not complete successfully: exit code: 1
```

### `curl`

```
 > [deps 2/7] RUN apk add --no-cache    bzip2=1.0.8-r6  curl=8.14.1-r2  tar=1.35-r3     unzip=6.0-r15:                               
0.431 fetch https://dl-cdn.alpinelinux.org/alpine/v3.22/main/x86_64/APKINDEX.tar.gz                                                  
0.728 fetch https://dl-cdn.alpinelinux.org/alpine/v3.22/community/x86_64/APKINDEX.tar.gz                                             
3.675 ERROR: unable to select packages:                                                                                              
3.685   curl-8.14.1-r3:                                                                                                              
3.685     breaks: world[curl=8.14.1-r2]
------
[+] build 0/1
 ⠙ Image zerobyte-zerobyte Building                                                                                             16.6s
Dockerfile:40

--------------------

  39 |     

  40 | >>> RUN apk add --no-cache \

  41 | >>> 	bzip2=1.0.8-r6 \

  42 | >>> 	curl=8.14.1-r2 \

  43 | >>> 	tar=1.35-r3 \

  44 | >>> 	unzip=6.0-r15

  45 |     

--------------------

failed to solve: process "/bin/sh -c apk add --no-cache \tbzip2=1.0.8-r6 \tcurl=8.14.1-r2 \ttar=1.35-r3 \tunzip=6.0-r15" did not complete successfully: exit code: 1
```

## Root cause

The Dockerfile pins specific versions of Alpine packages, but these versions become outdated as Alpine releases updates. Both tzdata and curl have been updated in the repository, causing the build to fail.

## Solution

Remove the version pins for tzdata and curl to allow Alpine's package manager to fetch the latest compatible versions.

## Why this approach?

- Future-proof: prevents the issue from reapearing when the packages are updated again
- Minimal changes: only removes pins for packages that causes issues
- Preserves stability: other packages remain pinned for compatibility reasons

## Testing

- Built the image locally with `docker compose build --no-cache`
- Verified the build completes successfully
- Started the container with `docker compose up`
- Confirmed the container runs without the Bun error

## Related issue

Fixes #1073 