### PR TITLE
fix: execute backup schedules sequentially instead of fire-and-forget

### DIFF
--- a/app/server/jobs/backup-execution.ts
+++ b/app/server/jobs/backup-execution.ts
@@ -23,7 +23,7 @@ export class BackupExecutionJob extends Job {
 				logger.info(`Found ${scheduleIds.length} backup schedule(s) to execute for organization ${org.name}`);
 
 				for (const scheduleId of scheduleIds) {
-					backupsService.executeBackup(scheduleId).catch((err: Error) => {
+					await backupsService.executeBackup(scheduleId).catch((err: Error) => {
 						logger.error(`Error executing backup for schedule ${scheduleId}:`, err);
 					});
 				}


### PR DESCRIPTION
## Summary

`BackupExecutionJob.run()` iterated over due schedules and called
`executeBackup(scheduleId)` without awaiting it, only attaching a
`.catch()` for error logging (fire-and-forget). This allows multiple
backups to run concurrently, which can overlap on the same restic
repository.

This PR adds a single `await` so each schedule's backup completes
before the next one starts, serializing execution per organization
tick.

Fixes #305.

## Test plan

- [x] Read the surrounding code: the loop already runs inside an
      `async` callback (`withContext(..., async () => { ... })`), so
      `await` is valid there with no other change needed.
- [ ] Would appreciate a maintainer/CI check on the existing
      integration suite (`bun run test:integration`) — I didn't run
      the full suite locally for this one-line change.

## Notes

Minimal, targeted fix — happy to adjust scope/style if you'd prefer a
different approach (e.g. explicit `Promise.allSettled` per schedule
with limited concurrency instead of full serialization).