### PR TITLE
fix(change-username): update displayed fields

### DIFF
--- a/app/server/cli/commands/change-username.test.ts
+++ b/app/server/cli/commands/change-username.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, test } from "vitest";
+import { eq } from "drizzle-orm";
+import { db } from "~/server/db/db";
+import { sessionsTable, usersTable } from "~/server/db/schema";
+import { changeUsername } from "./change-username";
+
+describe("changeUsername", () => {
+	beforeEach(async () => {
+		await db.delete(sessionsTable);
+		await db.delete(usersTable);
+	});
+
+	test("updates all username-derived identity fields and invalidates sessions", async () => {
+		const userId = Bun.randomUUIDv7();
+
+		await db.insert(usersTable).values({
+			id: userId,
+			username: "old_username",
+			name: "old_username",
+			displayUsername: "old_username",
+			email: "old@example.com",
+		});
+		await db.insert(sessionsTable).values({
+			id: Bun.randomUUIDv7(),
+			userId,
+			token: Bun.randomUUIDv7(),
+			expiresAt: new Date(Date.now() + 60_000),
+		});
+
+		await changeUsername("old_username", "New_Username");
+
+		const [updatedUser] = await db
+			.select({
+				username: usersTable.username,
+				name: usersTable.name,
+				displayUsername: usersTable.displayUsername,
+			})
+			.from(usersTable)
+			.where(eq(usersTable.id, userId));
+		expect(updatedUser).toEqual({
+			username: "new_username",
+			name: "new_username",
+			displayUsername: "new_username",
+		});
+
+		const sessions = await db
+			.select({ id: sessionsTable.id })
+			.from(sessionsTable)
+			.where(eq(sessionsTable.userId, userId));
+		expect(sessions).toHaveLength(0);
+	});
+});

--- a/app/server/cli/commands/change-username.ts
+++ b/app/server/cli/commands/change-username.ts
@@ -9,7 +9,7 @@ const listUsers = () => {
 	return db.select({ id: usersTable.id, username: usersTable.username }).from(usersTable);
 };
 
-const changeUsername = async (oldUsername: string, newUsername: string) => {
+export const changeUsername = async (oldUsername: string, newUsername: string) => {
 	const [user] = await db.select().from(usersTable).where(eq(usersTable.username, oldUsername));
 
 	if (!user) {
@@ -31,7 +31,13 @@ const changeUsername = async (oldUsername: string, newUsername: string) => {
 	}
 
 	db.transaction((tx) => {
-		tx.update(usersTable).set({ username: normalizedUsername }).where(eq(usersTable.id, user.id)).run();
+		const updatedIdentity = {
+			username: normalizedUsername,
+			name: normalizedUsername,
+			displayUsername: normalizedUsername,
+		};
+
+		tx.update(usersTable).set(updatedIdentity).where(eq(usersTable.id, user.id)).run();
 		tx.delete(sessionsTable).where(eq(sessionsTable.userId, user.id)).run();
 	});
 };


### PR DESCRIPTION
When changing the username with CLI the command would only change the internal username but not the display name of the account. Related issue #1099