### PR TITLE
fix(backups): read repository and destination lists from live queries

### DIFF
--- a/app/client/modules/backups/routes/__tests__/backup-details.test.tsx
+++ b/app/client/modules/backups/routes/__tests__/backup-details.test.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { fromAny } from "@total-typescript/shoehorn";
 import { HttpResponse, http, server } from "~/test/msw/server";
-import { cleanup, render, screen } from "~/test/test-utils";
+import { cleanup, createTestQueryClient, render, screen } from "~/test/test-utils";
 
 vi.mock("@tanstack/react-router", async (importOriginal) => {
 	const actual = await importOriginal<typeof import("@tanstack/react-router")>();
@@ -28,11 +28,23 @@ vi.mock("~/client/lib/datetime", async (importOriginal) => {
 });
 
 vi.mock("~/client/modules/backups/components/schedule-notifications-config", () => ({
-	ScheduleNotificationsConfig: () => null,
+	ScheduleNotificationsConfig: ({ destinations }: { destinations: Array<{ id: number; name: string }> }) => (
+		<ul>
+			{destinations.map((destination) => (
+				<li key={destination.id}>{destination.name}</li>
+			))}
+		</ul>
+	),
 }));
 
 vi.mock("~/client/modules/backups/components/schedule-mirrors-config", () => ({
-	ScheduleMirrorsConfig: () => null,
+	ScheduleMirrorsConfig: ({ repositories }: { repositories: Array<{ shortId: string; name: string }> }) => (
+		<ul>
+			{repositories.map((repository) => (
+				<li key={repository.shortId}>{repository.name}</li>
+			))}
+		</ul>
+	),
 }));
 
 vi.mock("~/client/modules/backups/components/schedule-summary", () => ({
@@ -106,6 +118,10 @@ const schedule = {
 	backupWebhooks: null,
 };
 
+const repository = { shortId: "repo-1", name: "Repo 1", type: "local" };
+const mirrorRepository = { shortId: "repo-2", name: "Repo 2", type: "s3" };
+const notificationDestination = { id: 1, name: "Ntfy", provider: "ntfy", enabled: true };
+
 const snapshot = {
 	short_id: "snap-1",
 	paths: ["/mnt/project"],
@@ -161,12 +177,20 @@ const mockScheduleDetailsRequests = (
 		onScheduleRequest?: () => void;
 		snapshots?: () => Array<typeof snapshot>;
 		tasks?: () => Array<typeof deleteSnapshotsTask>;
+		repositories?: () => Array<typeof repository>;
+		destinations?: () => Array<typeof notificationDestination>;
 	} = {},
 ) => {
 	server.use(
 		http.get("/api/v1/backups/:shortId", () => {
 			options.onScheduleRequest?.();
 			return HttpResponse.json({ ...schedule, ...options.scheduleOverride });
+		}),
+		http.get("/api/v1/repositories", () => {
+			return HttpResponse.json(options.repositories ? options.repositories() : [repository]);
+		}),
+		http.get("/api/v1/notifications/destinations", () => {
+			return HttpResponse.json(options.destinations ? options.destinations() : []);
 		}),
 		http.get("/api/v1/repositories/:shortId/snapshots", () => {
 			return HttpResponse.json(options.snapshots ? options.snapshots() : [snapshot]);
@@ -215,8 +239,6 @@ describe("ScheduleDetailsPage", () => {
 			<ScheduleDetailsPage
 				loaderData={fromAny({
 					schedule,
-					notifs: [],
-					repos: [],
 					scheduleNotifs: [],
 					mirrors: [],
 					snapshots: [snapshot],
@@ -243,6 +265,8 @@ describe("ScheduleDetailsPage", () => {
 
 		server.use(
 			http.get("/api/v1/backups/:shortId", () => HttpResponse.json(schedule)),
+			http.get("/api/v1/repositories", () => HttpResponse.json([repository])),
+			http.get("/api/v1/notifications/destinations", () => HttpResponse.json([])),
 			http.get(/\/api\/v1\/tasks(?:\?.*)?$/, () => HttpResponse.json([])),
 			http.get("/api/v1/repositories/:shortId/snapshots", () => snapshotsResponse),
 		);
@@ -251,8 +275,6 @@ describe("ScheduleDetailsPage", () => {
 			<ScheduleDetailsPage
 				loaderData={fromAny({
 					schedule,
-					notifs: [],
-					repos: [],
 					scheduleNotifs: [],
 					mirrors: [],
 					snapshots: [],
@@ -282,8 +304,6 @@ describe("ScheduleDetailsPage", () => {
 			<ScheduleDetailsPage
 				loaderData={fromAny({
 					schedule: fromAny({ ...schedule, lastBackupStatus: "in_progress" }),
-					notifs: [],
-					repos: [],
 					scheduleNotifs: [],
 					mirrors: [],
 					snapshots: [snapshot],
@@ -296,5 +316,37 @@ describe("ScheduleDetailsPage", () => {
 		expect(await screen.findByRole("heading", { name: "Backup 1" })).toBeTruthy();
 		await new Promise((resolve) => setTimeout(resolve, 1200));
 		expect(runningScheduleRequests).toBe(1);
+	});
+
+	test("shows repositories and destinations created after the page was loaded without a reload", async () => {
+		const repositories = [repository];
+		const destinations: Array<typeof notificationDestination> = [];
+		mockScheduleDetailsRequests({ repositories: () => repositories, destinations: () => destinations });
+
+		const queryClient = createTestQueryClient();
+
+		render(
+			<ScheduleDetailsPage
+				loaderData={fromAny({
+					schedule,
+					scheduleNotifs: [],
+					mirrors: [],
+					snapshots: [snapshot],
+				})}
+				scheduleId="backup-1"
+			/>,
+			{ withSuspense: true, queryClient },
+		);
+
+		expect(await screen.findByRole("heading", { name: "Backup 1" })).toBeTruthy();
+		expect(screen.queryByText("Repo 2")).toBeNull();
+		expect(screen.queryByText("Ntfy")).toBeNull();
+
+		repositories.push(mirrorRepository);
+		destinations.push(notificationDestination);
+		await queryClient.invalidateQueries();
+
+		expect(await screen.findByText("Repo 2")).toBeTruthy();
+		expect(await screen.findByText("Ntfy")).toBeTruthy();
 	});
 });

--- a/app/client/modules/backups/routes/backup-details.tsx
+++ b/app/client/modules/backups/routes/backup-details.tsx
@@ -16,6 +16,8 @@ import {
 	getBackupScheduleOptions,
 	runBackupNowMutation,
 	deleteBackupScheduleMutation,
+	listNotificationDestinationsOptions,
+	listRepositoriesOptions,
 	listSnapshotsOptions,
 	updateBackupScheduleMutation,
 	deleteSnapshotMutation,
@@ -30,21 +32,12 @@ import { ScheduleMirrorsConfig } from "../components/schedule-mirrors-config";
 import { BackupSummaryCard } from "~/client/components/backup-summary-card";
 import { cn } from "~/client/lib/utils";
 import { getVolumeMountPath } from "~/client/lib/volume-path";
-import type {
-	BackupSchedule,
-	NotificationDestination,
-	Repository,
-	ScheduleMirror,
-	ScheduleNotification,
-	Snapshot,
-} from "~/client/lib/types";
+import type { BackupSchedule, ScheduleMirror, ScheduleNotification, Snapshot } from "~/client/lib/types";
 import { useNavigate } from "@tanstack/react-router";
 
 type Props = {
 	loaderData: {
 		schedule: BackupSchedule;
-		notifs: NotificationDestination[];
-		repos: Repository[];
 		scheduleNotifs: ScheduleNotification[];
 		mirrors: ScheduleMirror[];
 		snapshots?: Snapshot[];
@@ -66,6 +59,14 @@ export function ScheduleDetailsPage(props: Props) {
 		...getBackupScheduleOptions({ path: { shortId: scheduleId } }),
 	});
 	const { deletingSnapshotIds } = useDeletingSnapshots(schedule.repository.shortId);
+
+	const { data: repositories } = useSuspenseQuery({
+		...listRepositoriesOptions(),
+	});
+
+	const { data: notificationDestinations } = useSuspenseQuery({
+		...listNotificationDestinationsOptions(),
+	});
 
 	const {
 		data: snapshots,
@@ -183,18 +184,18 @@ export function ScheduleDetailsPage(props: Props) {
 				handleDeleteSchedule={() => deleteSchedule.mutate({ path: { shortId: schedule.shortId } })}
 				schedule={schedule}
 			/>
-			<div className={cn({ hidden: !loaderData.notifs?.length })}>
+			<div className={cn({ hidden: notificationDestinations.length === 0 })}>
 				<ScheduleNotificationsConfig
 					scheduleShortId={schedule.shortId}
-					destinations={loaderData.notifs ?? []}
+					destinations={notificationDestinations}
 					initialData={loaderData.scheduleNotifs ?? []}
 				/>
 			</div>
-			<div className={cn({ hidden: !loaderData.repos?.length || loaderData.repos.length < 2 })}>
+			<div className={cn({ hidden: repositories.length < 2 })}>
 				<ScheduleMirrorsConfig
 					scheduleShortId={schedule.shortId}
 					primaryRepositoryId={schedule.repository.shortId}
-					repositories={loaderData.repos ?? []}
+					repositories={repositories}
 					initialData={loaderData.mirrors ?? []}
 				/>
 			</div>

--- a/app/routes/(dashboard)/backups/$backupId/index.tsx
+++ b/app/routes/(dashboard)/backups/$backupId/index.tsx
@@ -23,14 +23,14 @@ export const Route = createFileRoute("/(dashboard)/backups/$backupId/")({
 		const activeBackupTasksOptions = backupTasksOptions(backupId);
 		const activeMirrorSyncTasksOptions = mirrorSyncTasksOptions(backupId);
 
-		const [schedule, notifs, repos, scheduleNotifs, mirrors] = await Promise.all([
+		const [schedule, scheduleNotifs, mirrors] = await Promise.all([
 			context.queryClient.ensureQueryData({ ...getBackupScheduleOptions({ path: { shortId: backupId } }) }),
-			context.queryClient.ensureQueryData({ ...listNotificationDestinationsOptions() }),
-			context.queryClient.ensureQueryData({ ...listRepositoriesOptions() }),
 			context.queryClient.ensureQueryData({
 				...getScheduleNotificationsOptions({ path: { shortId: backupId } }),
 			}),
 			context.queryClient.ensureQueryData({ ...getScheduleMirrorsOptions({ path: { shortId: backupId } }) }),
+			context.queryClient.ensureQueryData({ ...listRepositoriesOptions() }),
+			context.queryClient.ensureQueryData({ ...listNotificationDestinationsOptions() }),
 			context.queryClient.ensureQueryData(activeBackupTasksOptions),
 			context.queryClient.ensureQueryData(activeMirrorSyncTasksOptions),
 		]);
@@ -47,8 +47,6 @@ export const Route = createFileRoute("/(dashboard)/backups/$backupId/")({
 
 		return {
 			schedule,
-			notifs,
-			repos,
 			scheduleNotifs,
 			mirrors,
 			snapshots: context.queryClient.getQueryData(snapshotOptions.queryKey),


### PR DESCRIPTION
## What

On the backup job details page, the **Mirror Repositories** picker and the **Notifications** config were rendering a stale list. A repository created after the app had loaded didn't appear in the mirror dropdown until a full browser reload; newly added notification destinations behaved the same way.

Worse, when going from one repository to two, the entire Mirror Repositories card stayed hidden, because its visibility check ran against the same stale array.

## Why

`app/routes/(dashboard)/backups/$backupId/index.tsx` resolved both lists with `ensureQueryData` and returned them as plain loader props, which `ScheduleDetailsPage` passed straight down to `ScheduleMirrorsConfig` / `ScheduleNotificationsConfig`.

Two things combine:

- `ensureQueryData` resolves from cache and never revalidates when an entry already exists (no `revalidateIfStale`), so the loader returns the stale list as-is.
- Because the result is a frozen loader snapshot rather than a live query, the background refetch React Query does perform can never reach the component.

By the time you create a repository you've already been on `/repositories`, so `listRepositories` is in the cache. The global `MutationCache.onSettled` in `app/router.tsx` marks it stale, but nothing is observing that key, so no refetch happens — and the loader hands the component the pre-creation array. Only a hard reload (fresh `queryClient`) clears it.

## How

Read both lists with `useSuspenseQuery` in the component, which is how every other repository and destination picker in the app already works (`basic-info-section.tsx`, `repositories.tsx`, `notifications.tsx`, `backups/$backupId/edit.tsx`). The loader keeps its `ensureQueryData` calls so the cache is still primed and navigation renders without a waterfall — it just no longer returns the data as props.

No API or behaviour changes beyond the lists now staying current.

## Testing

- Added a regression test in `backup-details.test.tsx` asserting that a repository and a notification destination created after page load show up without a reload. Verified it fails against the current code and passes with the fix.
- Full client suite passes (142 tests, 18 files), `tsc --noEmit` clean across all workspaces, oxlint and oxfmt clean on the changed files.

---

Developed with AI assistance; reviewed, tested, and verified by me.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Backup details now load repositories and notification destinations dynamically.
  * Newly created repositories and notification destinations appear automatically after updates.
  * Backup configuration sections now display current repository and notification destination data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->