### PR TITLE
fix(backups): preserve include and exclude patterns

### DIFF
--- a/app/server/modules/backups/__tests__/backups.patterns.test.ts
+++ b/app/server/modules/backups/__tests__/backups.patterns.test.ts
@@ -34,12 +34,8 @@ describe("executeBackup - include / exclude patterns", () => {
 		// assert
 		expect(options).toMatchObject({
 			includePaths: [path.join(volumePath, "Photos")],
-			includePatterns: [
-				path.join(volumePath, "*.zip"),
-				`!${path.join(volumePath, "Temp")}`,
-				`!${path.join(volumePath, "*.log")}`,
-			],
-			exclude: [".DS_Store", path.join(volumePath, "Config"), `!${path.join(volumePath, "Important")}`, "!*.tmp"],
+			includePatterns: ["*.zip", "!/Temp", "!*.log"],
+			exclude: [".DS_Store", "/Config", "!/Important", "!*.tmp"],
 			excludeIfPresent: [".nobackup"],
 		});
 	});

--- a/apps/agent/src/commands/helpers/__tests__/backup.helpers.test.ts
+++ b/apps/agent/src/commands/helpers/__tests__/backup.helpers.test.ts
@@ -52,33 +52,29 @@ describe("backup path options", () => {
 			tags: ["sched-1234"],
 			signal,
 			includePaths: [path.join(volumePath, "Photos")],
-			includePatterns: [
-				path.join(volumePath, "*.zip"),
-				`!${path.join(volumePath, "Temp")}`,
-				`!${path.join(volumePath, "*.log")}`,
-			],
-			exclude: [".DS_Store", path.join(volumePath, "Config"), `!${path.join(volumePath, "Important")}`, "!*.tmp"],
+			includePatterns: ["*.zip", "!/Temp", "!*.log"],
+			exclude: [".DS_Store", "/Config", "!/Important", "!*.tmp"],
 			excludeIfPresent: [".nobackup"],
 		});
 	});
 
-	test("keeps relative and negated relative exclude patterns unchanged", () => {
-		expect(processPattern("relative/include", "/volume")).toBe("relative/include");
-		expect(processPattern("!*.log", "/volume")).toBe("!*.log");
+	test("preserves patterns that already contain the volume path", () => {
+		const volumePath = "/docker";
+		const includePatterns = ["/docker/engine/buildkit", "!/docker/engine/tmp"];
+		const excludePatterns = ["/docker/engine/containers", "!/docker/engine/plugins"];
+
+		const options = createOptions(createPathOptions({ includePatterns, excludePatterns }), volumePath);
+
+		expect(options.includePatterns).toEqual(includePatterns);
+		expect(options.exclude).toEqual(excludePatterns);
 	});
 
-	test("anchors relative glob include patterns to the volume path", () => {
+	test("keeps relative glob include patterns unchanged", () => {
 		const volumePath = "/var/lib/zerobyte/volumes/vol123/_data";
-		const options = createOptions(
-			createPathOptions({ includePatterns: ["**/*.xyz", "*.zip", "!**/*.tmp"] }),
-			volumePath,
-		);
+		const includePatterns = ["**/*.xyz", "*.zip", "!**/*.tmp"];
+		const options = createOptions(createPathOptions({ includePatterns }), volumePath);
 
-		expect(options.includePatterns).toEqual([
-			path.join(volumePath, "**/*.xyz"),
-			path.join(volumePath, "*.zip"),
-			`!${path.join(volumePath, "**/*.tmp")}`,
-		]);
+		expect(options.includePatterns).toEqual(includePatterns);
 	});
 
 	test("handles a selected subfolder with the exact same name as the volume path", () => {
@@ -100,10 +96,7 @@ describe("backup path options", () => {
 			volumePath,
 		);
 
-		expect(options.includePatterns).toEqual([
-			path.join(volumePath, relativeInclude),
-			path.join(volumePath, "anchored/include"),
-		]);
+		expect(options.includePatterns).toEqual([relativeInclude, anchoredInclude]);
 	});
 
 	test("handles empty include and exclude patterns", () => {
@@ -117,17 +110,13 @@ describe("backup path options", () => {
 		expect(options.exclude).toEqual([]);
 	});
 
-	test("rejects include patterns that escape the volume root", () => {
+	test("passes include patterns through without resolving them as paths", () => {
 		const volumePath = "/var/lib/zerobyte/volumes/vol123/_data";
+		const includePatterns = ["../../../../etc/shadow", "/../etc/passwd", "!/../../secrets.txt"];
 
-		expect(() =>
-			createOptions(
-				createPathOptions({
-					includePatterns: ["../../../../etc/shadow", "/../etc/passwd", "!/../../secrets.txt"],
-				}),
-				volumePath,
-			),
-		).toThrow("Include pattern escapes volume root");
+		const options = createOptions(createPathOptions({ includePatterns }), volumePath);
+
+		expect(options.includePatterns).toEqual(includePatterns);
 	});
 
 	test("rejects unsupported characters in selected include paths", () => {
@@ -161,7 +150,7 @@ describe("backup path options", () => {
 		}
 	});
 
-	test("anchors generated include patterns under the volume path", () => {
+	test("anchors generated include paths under the volume path", () => {
 		const volumePath = "/var/lib/zerobyte/volumes/vol123/_data";
 
 		fc.assert(
@@ -174,7 +163,7 @@ describe("backup path options", () => {
 		);
 	});
 
-	test("rejects generated include patterns that escape the volume root", () => {
+	test("rejects generated include paths that escape the volume root", () => {
 		const volumePath = "/volume/root";
 
 		fc.assert(
@@ -197,6 +186,6 @@ describe("backup path options", () => {
 		);
 
 		expect(options.includePaths).toEqual([path.join(volumePath, "movies [1]")]);
-		expect(options.includePatterns).toEqual([path.join(volumePath, "**/*.txt")]);
+		expect(options.includePatterns).toEqual(["**/*.txt"]);
 	});
 });

--- a/apps/agent/src/commands/helpers/backup.helpers.ts
+++ b/apps/agent/src/commands/helpers/backup.helpers.ts
@@ -46,7 +46,7 @@ export const createBackupOptions = (
 	tags: [params.scheduleId],
 	oneFileSystem: params.options.oneFileSystem,
 	signal,
-	exclude: params.options.excludePatterns?.map((p) => processPattern(p, volumePath)) ?? undefined,
+	exclude: params.options.excludePatterns ?? undefined,
 	excludeIfPresent: params.options.excludeIfPresent ?? undefined,
 	includePaths:
 		params.options.includePaths?.map((p) => {
@@ -56,7 +56,7 @@ export const createBackupOptions = (
 	includePatterns:
 		params.options.includePatterns?.map((p) => {
 			validateIncludeEntry(p, "Include pattern", "text");
-			return processPattern(p, volumePath, true);
+			return p;
 		}) ?? undefined,
 	customResticParams: params.options.customResticParams ?? [],
 	compressionMode: params.options.compressionMode,


### PR DESCRIPTION
## Summary

- pass configured include and exclude patterns to Restic unchanged
- keep volume-relative resolution and safety validation for selected include paths
- add agent and server regression coverage for absolute, relative, glob, and negated patterns

## Testing

- `bun run fmt:check -- apps/agent/src/commands/helpers/backup.helpers.ts apps/agent/src/commands/helpers/__tests__/backup.helpers.test.ts app/server/modules/backups/__tests__/backups.patterns.test.ts`
- `bun run lint`
- `bun run tsc`
- `bun run test`
- `bun run build`

Closes #1128

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Backup include and exclude patterns are now preserved exactly as entered.
  * Relative and volume-escaping patterns are no longer automatically rewritten as paths.
  * Explicit include paths continue to be resolved correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->