### PR TITLE
fix(tasks): share SSE listeners across bundles

### DIFF
--- a/app/server/modules/tasks/__tests__/tasks.store-events.test.ts
+++ b/app/server/modules/tasks/__tests__/tasks.store-events.test.ts
@@ -1,0 +1,41 @@
+import { beforeEach, expect, test, vi } from "vitest";
+import { db } from "~/server/db/db";
+import { tasksTable } from "~/server/db/schema";
+import { ensureTestOrganization, TEST_ORG_ID } from "~/test/helpers/organization";
+
+beforeEach(async () => {
+	await ensureTestOrganization();
+	await db.delete(tasksTable);
+});
+
+test("delivers task changes across separate module instances", async () => {
+	const publisherStore = (await import("../tasks.store")).taskStore;
+	const task = publisherStore.create({
+		id: "cross-module-task",
+		organizationId: TEST_ORG_ID,
+		resourceType: "backup_schedule",
+		resourceId: "backup-1",
+		targetDisplayName: "Backup",
+		input: {
+			kind: "backup",
+			scheduleId: 1,
+			scheduleShortId: "backup-1",
+			manual: false,
+		},
+	});
+
+	vi.resetModules();
+	const subscriberStore = (await import("../tasks.store")).taskStore;
+	const changedTasks: string[] = [];
+	const unsubscribe = subscriberStore.subscribeToAllChanges({ organizationId: TEST_ORG_ID, kind: "backup" }, (task) =>
+		changedTasks.push(task.id),
+	);
+
+	try {
+		publisherStore.markRunning(task.id);
+
+		expect(changedTasks).toContain(task.id);
+	} finally {
+		unsubscribe();
+	}
+});

--- a/app/server/modules/tasks/tasks.store.ts
+++ b/app/server/modules/tasks/tasks.store.ts
@@ -50,6 +50,13 @@ type FindTaskParams = {
 	taskId: string;
 };
 type TaskChangeListener = (task: ParsedTask) => void;
+type TaskListenerState = {
+	taskListeners: Map<string, Set<TaskChangeListener>>;
+	allTaskListeners: Set<TaskChangeListener>;
+};
+type ProcessWithTaskListeners = NodeJS.Process & {
+	__zerobyteTaskListeners?: TaskListenerState;
+};
 
 export const RESTART_TASK_ERROR = "Zerobyte was restarted before this task completed";
 
@@ -81,10 +88,16 @@ const parseFinishedTask = (row: unknown): FinishedTask => {
 	return { ...task, status, finishedAt: task.finishedAt };
 };
 
-const taskListeners = new Map<string, Set<TaskChangeListener>>();
-const allTaskListeners = new Set<TaskChangeListener>();
+const getTaskListenerState = () => {
+	const runtimeProcess = process as ProcessWithTaskListeners;
+	return (runtimeProcess.__zerobyteTaskListeners ??= {
+		taskListeners: new Map(),
+		allTaskListeners: new Set(),
+	});
+};
 
 const emitTaskChanged = (task: ParsedTask) => {
+	const { taskListeners, allTaskListeners } = getTaskListenerState();
 	const listeners = taskListeners.get(task.id);
 	if (listeners) {
 		for (const listener of listeners) {
@@ -109,6 +122,7 @@ const emitTaskHistoryChanged = (task: ParsedTask, previousOutcome: TaskHistoryOu
 };
 
 const subscribeToAllTaskChanges = (listener: TaskChangeListener) => {
+	const { allTaskListeners } = getTaskListenerState();
 	allTaskListeners.add(listener);
 
 	return () => {
@@ -117,6 +131,7 @@ const subscribeToAllTaskChanges = (listener: TaskChangeListener) => {
 };
 
 const subscribeToTaskChanges = (taskId: string, listener: TaskChangeListener) => {
+	const { taskListeners } = getTaskListenerState();
 	let listeners = taskListeners.get(taskId);
 	if (!listeners) {
 		listeners = new Set();


### PR DESCRIPTION
## Summary

Fix delayed task progress updates delivered through Server-Sent Events in production builds.

## Root Cause

Nitro can load task producers and SSE route handlers from separate server bundles.

The task listener registry was stored in module-scoped `Map` and `Set` instances. As a result, backup execution could publish task progress through one module instance while the `/api/v1/tasks/events` endpoint subscribed through another.

The SSE connection remained open and continued receiving heartbeats, but task progress events were not delivered to the browser.

## Fix

Store the task listener registry on the shared Node.js process so all server bundle instances publish and subscribe through the same state.

No polling fallback was added. Progress continues to use the existing SSE implementation.

## Testing

Added a regression test that:

1. Creates a publisher from one task-store module instance.
2. Reloads the module and creates a subscriber from the second instance.
3. Verifies that task updates cross the module-instance boundary.

All 25 targeted task and SSE tests pass.
