### PR TITLE
feat(snapshots): improve navigation and file details

### DIFF
--- a/app/client/api-client/types.gen.ts
+++ b/app/client/api-client/types.gen.ts
@@ -2241,7 +2241,7 @@ export type ListSnapshotsResponses = {
         duration: number;
         tags: Array<string>;
         retentionCategories: Array<string>;
-        hostname?: string;
+        hostname: string;
         summary?: {
             files_new: number;
             files_changed: number;
@@ -2328,7 +2328,7 @@ export type GetSnapshotDetailsResponses = {
         duration: number;
         tags: Array<string>;
         retentionCategories: Array<string>;
-        hostname?: string;
+        hostname: string;
         summary?: {
             files_new: number;
             files_changed: number;

--- a/app/client/components/__test__/restore-form.test.tsx
+++ b/app/client/components/__test__/restore-form.test.tsx
@@ -4,7 +4,7 @@ import { HttpResponse, http, server } from "~/test/msw/server";
 import { cleanup, createTestQueryClient, render, screen, userEvent, waitFor, within } from "~/test/test-utils";
 import { taskChangedEventName } from "~/schemas/task-events";
 import type { TaskOfKind } from "~/client/hooks/use-active-tasks";
-import type { Repository } from "~/client/lib/types";
+import type { Repository, Snapshot } from "~/client/lib/types";
 import { fromAny } from "@total-typescript/shoehorn";
 import { RestoreSnapshotPage } from "~/client/modules/repositories/routes/restore-snapshot";
 
@@ -18,6 +18,17 @@ vi.mock("@tanstack/react-router", async (importOriginal) => {
 });
 
 import { RestoreForm } from "../restore-form";
+
+const snapshotFixture = (short_id: string): Snapshot => ({
+	short_id,
+	hostname: "backup-host",
+	time: Date.UTC(2026, 8, 9, 13, 30),
+	paths: ["/mnt/project"],
+	size: 0,
+	duration: 0,
+	tags: [],
+	retentionCategories: [],
+});
 
 class MockEventSource {
 	static instances: MockEventSource[] = [];
@@ -119,7 +130,7 @@ const renderRestoreForm = (queryClient = createTestQueryClient()) => {
 	return render(
 		<RestoreForm
 			repository={fromAny({ shortId: repositoryId, name: "Repo 1" })}
-			snapshotId={snapshotId}
+			snapshot={snapshotFixture(snapshotId)}
 			returnPath={`/repositories/${repositoryId}/${snapshotId}`}
 			queryBasePath="/mnt/project"
 			displayBasePath="/mnt"
@@ -348,7 +359,11 @@ describe("RestoreForm", () => {
 		server.use(snapshotFilesHandler);
 		const repository: Repository = fromAny({ shortId: repositoryId, name: "Repo 1" });
 		const { rerender } = render(
-			<RestoreSnapshotPage repository={repository} snapshotId="snap-1" returnPath="/repositories/repo-1" />,
+			<RestoreSnapshotPage
+				repository={repository}
+				snapshot={snapshotFixture("snap-1")}
+				returnPath="/repositories/repo-1"
+			/>,
 			{ withSuspense: true },
 		);
 		const firstStreamUrl =
@@ -363,7 +378,13 @@ describe("RestoreForm", () => {
 
 		expect(await screen.findByText("Restore completed")).toBeTruthy();
 
-		rerender(<RestoreSnapshotPage repository={repository} snapshotId="snap-2" returnPath="/repositories/repo-1" />);
+		rerender(
+			<RestoreSnapshotPage
+				repository={repository}
+				snapshot={snapshotFixture("snap-2")}
+				returnPath="/repositories/repo-1"
+			/>,
+		);
 
 		await waitFor(() => {
 			expect(
@@ -403,7 +424,7 @@ describe("RestoreForm", () => {
 		render(
 			<RestoreForm
 				repository={fromAny({ shortId: "repo-1", name: "Repo 1" })}
-				snapshotId="snap-1"
+				snapshot={snapshotFixture("snap-1")}
 				returnPath="/repositories/repo-1/snap-1"
 				queryBasePath="/mnt/project/subdir"
 				displayBasePath="/mnt"
@@ -457,7 +478,7 @@ describe("RestoreForm", () => {
 		render(
 			<RestoreForm
 				repository={fromAny({ shortId: "repo-1", name: "Repo 1" })}
-				snapshotId="snap-1"
+				snapshot={snapshotFixture("snap-1")}
 				returnPath="/repositories/repo-1/snap-1"
 				queryBasePath="/mnt/project"
 				displayBasePath="/other/root"
@@ -523,7 +544,7 @@ describe("RestoreForm", () => {
 		render(
 			<RestoreForm
 				repository={fromAny({ shortId: "repo-1", name: "Repo 1" })}
-				snapshotId="snap-1"
+				snapshot={snapshotFixture("snap-1")}
 				returnPath="/repositories/repo-1/snap-1"
 				queryBasePath="/mnt/project"
 				displayBasePath="/mnt"

--- a/app/client/components/file-browsers/__tests__/snapshot-tree-browser.test.tsx
+++ b/app/client/components/file-browsers/__tests__/snapshot-tree-browser.test.tsx
@@ -18,9 +18,20 @@ const snapshotFiles = {
 	],
 };
 
+type SnapshotFilesResponse = {
+	files: Array<{
+		name: string;
+		path: string;
+		type: string;
+		size?: number;
+		mode?: number;
+		mtime?: string;
+	}>;
+};
+
 import { SnapshotTreeBrowser } from "../snapshot-tree-browser";
 
-const mockListSnapshotFiles = (response = snapshotFiles) => {
+const mockListSnapshotFiles = (response: SnapshotFilesResponse = snapshotFiles) => {
 	const requests: SnapshotFilesRequest[] = [];
 
 	server.use(
@@ -241,5 +252,34 @@ describe("SnapshotTreeBrowser", () => {
 		}
 
 		expect(await screen.findByRole("button", { name: "a.txt" })).toBeTruthy();
+	});
+
+	test("shows available attributes for the selected entry", async () => {
+		mockListSnapshotFiles({
+			files: [
+				{ name: "project", path: "/mnt/project", type: "dir" },
+				{
+					name: "a.txt",
+					path: "/mnt/project/a.txt",
+					type: "file",
+					size: 1024,
+					mode: 0o100644,
+					mtime: "2026-08-13T23:35:02Z",
+				},
+			],
+		});
+
+		renderSnapshotTreeBrowser();
+
+		const folder = await screen.findByRole("button", { name: "project" });
+		const expandIcon = folder.querySelector("svg");
+		if (!expandIcon) throw new Error("Expected expand icon for folder row");
+		fireEvent.click(expandIcon);
+
+		await userEvent.click(await screen.findByRole("button", { name: /^a\.txt/ }));
+
+		expect(screen.getByText("/project/a.txt")).toBeTruthy();
+		expect(screen.getAllByText("1 KiB")).toHaveLength(2);
+		expect(screen.getByText("0644")).toBeTruthy();
 	});
 });

--- a/app/client/components/file-browsers/__tests__/snapshot-tree-browser.test.tsx
+++ b/app/client/components/file-browsers/__tests__/snapshot-tree-browser.test.tsx
@@ -18,18 +18,10 @@ const snapshotFiles = {
 	],
 };
 
-type SnapshotFilesResponse = {
-	files: Array<{
-		name: string;
-		path: string;
-		type: string;
-		size?: number;
-		mode?: number;
-		mtime?: string;
-	}>;
-};
+type SnapshotFilesResponse = Pick<ListSnapshotFilesResponse, "files">;
 
 import { SnapshotTreeBrowser } from "../snapshot-tree-browser";
+import type { ListSnapshotFilesResponse } from "~/client/api-client";
 
 const mockListSnapshotFiles = (response: SnapshotFilesResponse = snapshotFiles) => {
 	const requests: SnapshotFilesRequest[] = [];
@@ -69,6 +61,34 @@ afterEach(() => {
 });
 
 describe("SnapshotTreeBrowser", () => {
+	test("inspects a synthesized ancestor independently of restore selection", async () => {
+		mockListSnapshotFiles({ files: [{ name: "report.txt", path: "/mnt/project/report.txt", type: "file" }] });
+		renderSnapshotTreeBrowser({
+			queryBasePath: "/mnt/project/report.txt",
+			withCheckboxes: true,
+			selectedPaths: new Set(["/mnt/project"]),
+		});
+		const row = await screen.findByRole("button", { name: "project" });
+		await userEvent.click(row);
+		const details = screen.getByRole("region", { name: "Selected entry details" });
+		expect(within(details).getByText("/project")).toBeTruthy();
+		expect(within(details).getByText("Directory")).toBeTruthy();
+		expect(within(row).getByRole("checkbox").getAttribute("aria-checked")).toBe("true");
+	});
+
+	test("retains metadata for a real directory even when its child appears first", async () => {
+		mockListSnapshotFiles({
+			files: [
+				{ name: "report.txt", path: "/mnt/project/report.txt", type: "file" },
+				{ name: "project", path: "/mnt/project", type: "dir", mode: 0o40750, mtime: "1970-01-01T00:00:00Z" },
+			],
+		});
+		renderSnapshotTreeBrowser();
+		await userEvent.click(await screen.findByRole("button", { name: "project" }));
+		const details = screen.getByRole("region", { name: "Selected entry details" });
+		expect(within(details).getByText("0750")).toBeTruthy();
+		expect(within(details).getByText(/1970/)).toBeTruthy();
+	});
 	test("renders the query root folder when display base path is broader than query base path", async () => {
 		mockListSnapshotFiles();
 

--- a/app/client/components/file-browsers/snapshot-entry-details.tsx
+++ b/app/client/components/file-browsers/snapshot-entry-details.tsx
@@ -1,0 +1,42 @@
+import { ByteSize } from "~/client/components/bytes-size";
+import type { FileEntry } from "~/client/components/file-tree-model";
+import { useTimeFormat } from "~/client/lib/datetime";
+
+export function SnapshotEntryDetails({ entry }: { entry: FileEntry }) {
+	const { formatDateTime } = useTimeFormat();
+	return (
+		<section
+			className="shrink-0 border-t bg-muted/30 px-4 py-3"
+			aria-label="Selected entry details"
+			aria-live="polite"
+		>
+			<div className="mb-2 truncate text-sm font-medium" title={entry.path}>
+				{entry.path}
+			</div>
+			<dl className="grid grid-cols-2 gap-x-6 gap-y-2 text-xs sm:grid-cols-4">
+				<div>
+					<dt className="text-muted-foreground">Type</dt>
+					<dd className="mt-0.5 capitalize">{entry.type === "dir" ? "Directory" : entry.type}</dd>
+				</div>
+				<div>
+					<dt className="text-muted-foreground">Size</dt>
+					<dd className="mt-0.5">
+						{entry.size === undefined ? "-" : <ByteSize bytes={entry.size} base={1024} />}
+					</dd>
+				</div>
+				<div>
+					<dt className="text-muted-foreground">Modified</dt>
+					<dd className="mt-0.5">
+						{entry.modifiedAt === undefined ? "-" : formatDateTime(new Date(entry.modifiedAt))}
+					</dd>
+				</div>
+				<div>
+					<dt className="text-muted-foreground">Permissions</dt>
+					<dd className="mt-0.5 font-mono">
+						{entry.mode === undefined ? "-" : (entry.mode & 0o7777).toString(8).padStart(4, "0")}
+					</dd>
+				</div>
+			</dl>
+		</section>
+	);
+}

--- a/app/client/components/file-browsers/snapshot-tree-browser.tsx
+++ b/app/client/components/file-browsers/snapshot-tree-browser.tsx
@@ -1,10 +1,12 @@
-import { useCallback, useMemo } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { listSnapshotFilesOptions } from "~/client/api-client/@tanstack/react-query.gen";
 import { FileBrowser, type FileBrowserUiProps } from "~/client/components/file-browsers/file-browser";
 import { useFileBrowser } from "~/client/hooks/use-file-browser";
 import { parseError } from "~/client/lib/errors";
 import { isPathWithin, normalizeAbsolutePath } from "@zerobyte/core/utils";
+import { ByteSize } from "~/client/components/bytes-size";
+import { useTimeFormat } from "~/client/lib/datetime";
 
 function createPathPrefixFns(basePath: string) {
 	return {
@@ -45,6 +47,8 @@ export const SnapshotTreeBrowser = (props: SnapshotTreeBrowserProps) => {
 
 	const { selectedPaths, onSelectionChange, onSingleSelectionKindChange, ...fileBrowserUiProps } = uiProps;
 	const queryClient = useQueryClient();
+	const { formatDateTime } = useTimeFormat();
+	const [selectedEntryPath, setSelectedEntryPath] = useState<string>();
 	const normalizedQueryBasePath = normalizeAbsolutePath(queryBasePath);
 	const normalizedDisplayBasePath = normalizeAbsolutePath(displayBasePath ?? "/");
 	const effectiveDisplayBasePath = isPathWithin(normalizedDisplayBasePath, normalizedQueryBasePath)
@@ -108,6 +112,7 @@ export const SnapshotTreeBrowser = (props: SnapshotTreeBrowserProps) => {
 		}
 		return kinds;
 	}, [fileBrowser.fileArray]);
+	const selectedEntry = fileBrowser.fileArray.find((entry) => entry.path === selectedEntryPath);
 
 	const handleSelectionChange = useCallback(
 		(nextDisplayPaths: Set<string>) => {
@@ -137,22 +142,72 @@ export const SnapshotTreeBrowser = (props: SnapshotTreeBrowserProps) => {
 	);
 
 	return (
-		<FileBrowser
-			{...fileBrowserUiProps}
-			folderErrors={fileBrowser.folderErrors}
-			fileArray={fileBrowser.fileArray}
-			expandedFolders={fileBrowser.expandedFolders}
-			loadingFolders={fileBrowser.loadingFolders}
-			onFolderToggle={fileBrowser.handleFolderToggle}
-			onFolderHover={fileBrowser.handleFolderHover}
-			onLoadMore={fileBrowser.handleLoadMore}
-			getFolderPagination={fileBrowser.getFolderPagination}
-			isLoading={fileBrowser.isLoading}
-			isEmpty={fileBrowser.isEmpty}
-			errorMessage={parseError(error)?.message}
-			loadingMessage={fileBrowserUiProps.loadingMessage ?? "Loading files..."}
-			selectedPaths={displaySelectedPaths}
-			onSelectionChange={onSelectionChange ? handleSelectionChange : undefined}
-		/>
+		<>
+			<FileBrowser
+				{...fileBrowserUiProps}
+				folderErrors={fileBrowser.folderErrors}
+				fileArray={fileBrowser.fileArray}
+				expandedFolders={fileBrowser.expandedFolders}
+				loadingFolders={fileBrowser.loadingFolders}
+				onFolderToggle={fileBrowser.handleFolderToggle}
+				onFolderHover={fileBrowser.handleFolderHover}
+				onLoadMore={fileBrowser.handleLoadMore}
+				getFolderPagination={fileBrowser.getFolderPagination}
+				isLoading={fileBrowser.isLoading}
+				isEmpty={fileBrowser.isEmpty}
+				errorMessage={parseError(error)?.message}
+				loadingMessage={fileBrowserUiProps.loadingMessage ?? "Loading files..."}
+				selectedPaths={displaySelectedPaths}
+				onSelectionChange={onSelectionChange ? handleSelectionChange : undefined}
+				selectableFolders
+				selectedFile={selectedEntry?.type === "file" ? selectedEntryPath : undefined}
+				selectedFolder={selectedEntry && selectedEntry.type !== "file" ? selectedEntryPath : undefined}
+				onFileSelect={setSelectedEntryPath}
+				onFolderSelect={setSelectedEntryPath}
+			/>
+			{selectedEntry && (
+				<div className="border-t bg-muted/30 px-4 py-3" aria-live="polite">
+					<div className="mb-2 truncate text-sm font-medium" title={selectedEntry.path}>
+						{selectedEntry.path}
+					</div>
+					<dl className="grid grid-cols-2 gap-x-6 gap-y-2 text-xs sm:grid-cols-4">
+						<div>
+							<dt className="text-muted-foreground">Type</dt>
+							<dd className="mt-0.5 capitalize">
+								{selectedEntry.type === "dir" ? "Directory" : selectedEntry.type}
+							</dd>
+						</div>
+						<div>
+							<dt className="text-muted-foreground">Size</dt>
+							<dd className="mt-0.5">
+								{typeof selectedEntry.size === "number" ? (
+									<ByteSize bytes={selectedEntry.size} base={1024} />
+								) : (
+									"-"
+								)}
+							</dd>
+						</div>
+						<div>
+							<dt className="text-muted-foreground">Modified</dt>
+							<dd className="mt-0.5">
+								{selectedEntry.mtime
+									? formatDateTime(selectedEntry.mtime)
+									: selectedEntry.modifiedAt
+										? formatDateTime(selectedEntry.modifiedAt)
+										: "-"}
+							</dd>
+						</div>
+						<div>
+							<dt className="text-muted-foreground">Permissions</dt>
+							<dd className="mt-0.5 font-mono">
+								{typeof selectedEntry.mode === "number"
+									? (selectedEntry.mode & 0o7777).toString(8).padStart(4, "0")
+									: "-"}
+							</dd>
+						</div>
+					</dl>
+				</div>
+			)}
+		</>
 	);
 };

--- a/app/client/components/file-browsers/snapshot-tree-browser.tsx
+++ b/app/client/components/file-browsers/snapshot-tree-browser.tsx
@@ -5,8 +5,19 @@ import { FileBrowser, type FileBrowserUiProps } from "~/client/components/file-b
 import { useFileBrowser } from "~/client/hooks/use-file-browser";
 import { parseError } from "~/client/lib/errors";
 import { isPathWithin, normalizeAbsolutePath } from "@zerobyte/core/utils";
-import { ByteSize } from "~/client/components/bytes-size";
-import { useTimeFormat } from "~/client/lib/datetime";
+import type { ListSnapshotFilesResponse } from "~/client/api-client";
+import { buildFileEntryMap } from "~/client/components/file-tree-model";
+import { SnapshotEntryDetails } from "./snapshot-entry-details";
+
+function toBrowserFiles(data: ListSnapshotFilesResponse) {
+	return {
+		...data,
+		files: data.files.map(({ mtime, ...file }) => ({
+			...file,
+			modifiedAt: mtime === undefined ? undefined : new Date(mtime).getTime(),
+		})),
+	};
+}
 
 function createPathPrefixFns(basePath: string) {
 	return {
@@ -24,7 +35,17 @@ function createPathPrefixFns(basePath: string) {
 	};
 }
 
-type SnapshotTreeBrowserProps = FileBrowserUiProps & {
+type SnapshotTreeBrowserProps = Omit<
+	FileBrowserUiProps,
+	| "selectableFolders"
+	| "selectedFile"
+	| "selectedFolder"
+	| "onFileSelect"
+	| "onFolderSelect"
+	| "showSelectedPathFooter"
+	| "selectedPath"
+	| "selectedPathLabel"
+> & {
 	repositoryId: string;
 	snapshotId: string;
 	queryBasePath?: string;
@@ -45,9 +66,8 @@ export const SnapshotTreeBrowser = (props: SnapshotTreeBrowserProps) => {
 		...uiProps
 	} = props;
 
-	const { selectedPaths, onSelectionChange, onSingleSelectionKindChange, ...fileBrowserUiProps } = uiProps;
+	const { className, selectedPaths, onSelectionChange, onSingleSelectionKindChange, ...fileBrowserUiProps } = uiProps;
 	const queryClient = useQueryClient();
-	const { formatDateTime } = useTimeFormat();
 	const [selectedEntryPath, setSelectedEntryPath] = useState<string>();
 	const normalizedQueryBasePath = normalizeAbsolutePath(queryBasePath);
 	const normalizedDisplayBasePath = normalizeAbsolutePath(displayBasePath ?? "/");
@@ -76,43 +96,25 @@ export const SnapshotTreeBrowser = (props: SnapshotTreeBrowserProps) => {
 		return displayPaths;
 	}, [displayPathFns, selectedPaths]);
 
+	const initialData = useMemo(() => data && toBrowserFiles(data), [data]);
 	const fileBrowser = useFileBrowser({
-		initialData: data,
+		initialData,
 		isLoading,
 		fetchFolder: async (displayPath, offset = 0) => {
-			return await queryClient.ensureQueryData(
-				listSnapshotFilesOptions({
-					path: { shortId: repositoryId, snapshotId },
-					query: { path: displayPath, offset: offset, limit: pageSize },
-				}),
+			return toBrowserFiles(
+				await queryClient.ensureQueryData(
+					listSnapshotFilesOptions({
+						path: { shortId: repositoryId, snapshotId },
+						query: { path: displayPath, offset: offset, limit: pageSize },
+					}),
+				),
 			);
 		},
 		pathTransform: displayPathFns,
 	});
 
-	const displayPathKinds = useMemo(() => {
-		const kinds = new Map<string, "file" | "dir">();
-		for (const entry of fileBrowser.fileArray) {
-			kinds.set(entry.path, entry.type === "file" ? "file" : "dir");
-
-			let parentPath = entry.path;
-			while (true) {
-				const lastSlashIndex = parentPath.lastIndexOf("/");
-				if (lastSlashIndex <= 0) {
-					break;
-				}
-
-				parentPath = parentPath.slice(0, lastSlashIndex);
-				if (kinds.has(parentPath)) {
-					continue;
-				}
-
-				kinds.set(parentPath, "dir");
-			}
-		}
-		return kinds;
-	}, [fileBrowser.fileArray]);
-	const selectedEntry = fileBrowser.fileArray.find((entry) => entry.path === selectedEntryPath);
+	const entries = useMemo(() => buildFileEntryMap(fileBrowser.fileArray), [fileBrowser.fileArray]);
+	const selectedEntry = selectedEntryPath === undefined ? undefined : entries.get(selectedEntryPath);
 
 	const handleSelectionChange = useCallback(
 		(nextDisplayPaths: Set<string>) => {
@@ -123,28 +125,20 @@ export const SnapshotTreeBrowser = (props: SnapshotTreeBrowserProps) => {
 				nextFullPaths.add(displayPathFns.add(displayPath));
 			}
 
-			if (onSingleSelectionKindChange) {
-				if (nextDisplayPaths.size === 1) {
-					const [selectedDisplayPath] = nextDisplayPaths;
-					if (selectedDisplayPath) {
-						onSingleSelectionKindChange(displayPathKinds.get(selectedDisplayPath) ?? null);
-					} else {
-						onSingleSelectionKindChange(null);
-					}
-				} else {
-					onSingleSelectionKindChange(null);
-				}
-			}
+			const [path] = nextDisplayPaths;
+			const entry = nextDisplayPaths.size === 1 && path !== undefined ? entries.get(path) : undefined;
+			onSingleSelectionKindChange?.(entry ? (entry.type === "file" ? "file" : "dir") : null);
 
 			onSelectionChange(nextFullPaths);
 		},
-		[displayPathFns, displayPathKinds, onSelectionChange, onSingleSelectionKindChange],
+		[displayPathFns, entries, onSelectionChange, onSingleSelectionKindChange],
 	);
 
 	return (
-		<>
+		<div className={`flex min-h-0 flex-1 flex-col ${className ?? ""}`}>
 			<FileBrowser
 				{...fileBrowserUiProps}
+				className="flex flex-1 min-h-0 flex-col"
 				folderErrors={fileBrowser.folderErrors}
 				fileArray={fileBrowser.fileArray}
 				expandedFolders={fileBrowser.expandedFolders}
@@ -165,49 +159,7 @@ export const SnapshotTreeBrowser = (props: SnapshotTreeBrowserProps) => {
 				onFileSelect={setSelectedEntryPath}
 				onFolderSelect={setSelectedEntryPath}
 			/>
-			{selectedEntry && (
-				<div className="border-t bg-muted/30 px-4 py-3" aria-live="polite">
-					<div className="mb-2 truncate text-sm font-medium" title={selectedEntry.path}>
-						{selectedEntry.path}
-					</div>
-					<dl className="grid grid-cols-2 gap-x-6 gap-y-2 text-xs sm:grid-cols-4">
-						<div>
-							<dt className="text-muted-foreground">Type</dt>
-							<dd className="mt-0.5 capitalize">
-								{selectedEntry.type === "dir" ? "Directory" : selectedEntry.type}
-							</dd>
-						</div>
-						<div>
-							<dt className="text-muted-foreground">Size</dt>
-							<dd className="mt-0.5">
-								{typeof selectedEntry.size === "number" ? (
-									<ByteSize bytes={selectedEntry.size} base={1024} />
-								) : (
-									"-"
-								)}
-							</dd>
-						</div>
-						<div>
-							<dt className="text-muted-foreground">Modified</dt>
-							<dd className="mt-0.5">
-								{selectedEntry.mtime
-									? formatDateTime(selectedEntry.mtime)
-									: selectedEntry.modifiedAt
-										? formatDateTime(selectedEntry.modifiedAt)
-										: "-"}
-							</dd>
-						</div>
-						<div>
-							<dt className="text-muted-foreground">Permissions</dt>
-							<dd className="mt-0.5 font-mono">
-								{typeof selectedEntry.mode === "number"
-									? (selectedEntry.mode & 0o7777).toString(8).padStart(4, "0")
-									: "-"}
-							</dd>
-						</div>
-					</dl>
-				</div>
-			)}
-		</>
+			{selectedEntry && <SnapshotEntryDetails entry={selectedEntry} />}
+		</div>
 	);
 };

--- a/app/client/components/file-tree-model.ts
+++ b/app/client/components/file-tree-model.ts
@@ -1,0 +1,23 @@
+export interface FileEntry {
+	name: string;
+	path: string;
+	type: string;
+	size?: number;
+	modifiedAt?: number;
+	mode?: number;
+}
+
+export function buildFileEntryMap(files: FileEntry[]): Map<string, FileEntry> {
+	const entries = new Map(files.map((file) => [file.path, file]));
+
+	for (const file of files) {
+		let path = file.path;
+		while (path.lastIndexOf("/") > 0) {
+			path = path.slice(0, path.lastIndexOf("/"));
+			if (entries.has(path)) break;
+			entries.set(path, { path, name: path.slice(path.lastIndexOf("/") + 1), type: "dir" });
+		}
+	}
+
+	return entries;
+}

--- a/app/client/components/file-tree.tsx
+++ b/app/client/components/file-tree.tsx
@@ -30,6 +30,8 @@ export interface FileEntry {
 	type: string;
 	size?: number;
 	modifiedAt?: number;
+	mode?: number;
+	mtime?: string;
 }
 
 interface PaginationState {

--- a/app/client/components/file-tree.tsx
+++ b/app/client/components/file-tree.tsx
@@ -21,18 +21,10 @@ import { memo, type ReactNode, useCallback, useMemo } from "react";
 import { cn } from "~/client/lib/utils";
 import { Checkbox } from "~/client/components/ui/checkbox";
 import { ByteSize } from "~/client/components/bytes-size";
+import { buildFileEntryMap, type FileEntry } from "./file-tree-model";
+export type { FileEntry } from "./file-tree-model";
 
 const NODE_PADDING_LEFT = 12;
-
-export interface FileEntry {
-	name: string;
-	path: string;
-	type: string;
-	size?: number;
-	modifiedAt?: number;
-	mode?: number;
-	mtime?: string;
-}
 
 interface PaginationState {
 	hasMore: boolean;
@@ -627,12 +619,9 @@ interface FolderNode extends BaseNode {
 
 function buildFileList(files: FileEntry[], foldersOnly = false): Node[] {
 	const fileMap = new Map<string, Node>();
+	const entries = buildFileEntryMap(foldersOnly ? files.filter((file) => file.type !== "file") : files);
 
-	for (const file of files) {
-		if (foldersOnly && file.type === "file") {
-			continue;
-		}
-
+	for (const file of entries.values()) {
 		const segments = file.path.split("/").filter((segment) => segment);
 		const depth = segments.length - 1;
 		const name = segments[segments.length - 1];
@@ -650,33 +639,6 @@ function buildFileList(files: FileEntry[], foldersOnly = false): Node[] {
 				fullPath: file.path,
 				depth,
 				size: file.size,
-			});
-		}
-
-		let parentPath = file.path;
-		while (true) {
-			const lastSlashIndex = parentPath.lastIndexOf("/");
-			if (lastSlashIndex <= 0) {
-				break;
-			}
-
-			parentPath = parentPath.slice(0, lastSlashIndex);
-			if (fileMap.has(parentPath)) {
-				continue;
-			}
-
-			const parentSegments = parentPath.split("/").filter((segment) => segment);
-			const parentName = parentSegments[parentSegments.length - 1];
-			if (!parentName) {
-				continue;
-			}
-
-			fileMap.set(parentPath, {
-				kind: "folder",
-				id: fileMap.size,
-				name: parentName,
-				fullPath: parentPath,
-				depth: parentSegments.length - 1,
 			});
 		}
 	}

--- a/app/client/components/restore-form.tsx
+++ b/app/client/components/restore-form.tsx
@@ -24,10 +24,11 @@ import { cancelTaskMutation, restoreSnapshotMutation } from "~/client/api-client
 import { useRestoreTask } from "~/client/modules/repositories/restore-tasks";
 import { OVERWRITE_MODES, type OverwriteMode } from "@zerobyte/core/restic";
 import { isPathWithin } from "@zerobyte/core/utils";
-import type { Repository } from "~/client/lib/types";
+import type { Repository, Snapshot } from "~/client/lib/types";
 import { handleRepositoryError } from "~/client/lib/errors";
 import { useNavigate } from "@tanstack/react-router";
 import { cn } from "~/client/lib/utils";
+import { useTimeFormat } from "~/client/lib/datetime";
 
 type RestoreLocation = "original" | "custom";
 
@@ -39,6 +40,7 @@ interface RestoreFormProps {
 	displayBasePath?: string;
 	hasNonPosixSnapshotPaths?: boolean;
 	volumeReadOnly?: boolean;
+	snapshot?: Snapshot;
 }
 
 export function RestoreForm({
@@ -49,8 +51,10 @@ export function RestoreForm({
 	displayBasePath,
 	hasNonPosixSnapshotPaths = false,
 	volumeReadOnly = false,
+	snapshot,
 }: RestoreFormProps) {
 	const navigate = useNavigate();
+	const { formatDateTime } = useTimeFormat();
 
 	const snapshotBasePath = queryBasePath ?? "/";
 	const hasMismatchedDisplayBasePath = displayBasePath && !isPathWithin(displayBasePath, snapshotBasePath);
@@ -196,6 +200,8 @@ export function RestoreForm({
 					<h1 className="text-2xl font-bold">Restore Snapshot</h1>
 					<p className="text-sm text-muted-foreground">
 						{repository.name} / {snapshotId}
+						{snapshot?.hostname && ` / ${snapshot.hostname}`}
+						{snapshot?.time && ` / ${formatDateTime(snapshot.time)}`}
 					</p>
 				</div>
 				<div className="flex flex-wrap gap-2">

--- a/app/client/components/restore-form.tsx
+++ b/app/client/components/restore-form.tsx
@@ -34,25 +34,24 @@ type RestoreLocation = "original" | "custom";
 
 interface RestoreFormProps {
 	repository: Repository;
-	snapshotId: string;
+	snapshot: Snapshot;
 	returnPath: string;
 	queryBasePath?: string;
 	displayBasePath?: string;
 	hasNonPosixSnapshotPaths?: boolean;
 	volumeReadOnly?: boolean;
-	snapshot?: Snapshot;
 }
 
 export function RestoreForm({
 	repository,
-	snapshotId,
+	snapshot,
 	returnPath,
 	queryBasePath,
 	displayBasePath,
 	hasNonPosixSnapshotPaths = false,
 	volumeReadOnly = false,
-	snapshot,
 }: RestoreFormProps) {
+	const snapshotId = snapshot.short_id;
 	const navigate = useNavigate();
 	const { formatDateTime } = useTimeFormat();
 
@@ -200,8 +199,7 @@ export function RestoreForm({
 					<h1 className="text-2xl font-bold">Restore Snapshot</h1>
 					<p className="text-sm text-muted-foreground">
 						{repository.name} / {snapshotId}
-						{snapshot?.hostname && ` / ${snapshot.hostname}`}
-						{snapshot?.time && ` / ${formatDateTime(snapshot.time)}`}
+						{` / ${snapshot.hostname || "Unknown"} / ${formatDateTime(snapshot.time)}`}
 					</p>
 				</div>
 				<div className="flex flex-wrap gap-2">
@@ -378,7 +376,7 @@ export function RestoreForm({
 						)}
 					</Card>
 				</div>
-				<Card className="lg:col-span-2 flex flex-col">
+				<Card className="lg:col-span-2 flex flex-col pb-0">
 					<CardHeader>
 						<CardTitle>Select Files to Restore</CardTitle>
 						<CardDescription>

--- a/app/client/components/snapshots-table.tsx
+++ b/app/client/components/snapshots-table.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { useMutation } from "@tanstack/react-query";
-import { Calendar, Clock, Database, HardDrive, Loader2, Tag, Trash2, X } from "lucide-react";
+import { Calendar, Clock, Database, HardDrive, Loader2, Monitor, Tag, Trash2, X } from "lucide-react";
 import { toast } from "sonner";
 import { ByteSize } from "~/client/components/bytes-size";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "~/client/components/ui/table";
@@ -212,6 +212,7 @@ export const SnapshotsTable = ({ snapshots, repositoryId, backups }: Props) => {
 							</TableHead>
 							<TableHead className="uppercase">Snapshot ID</TableHead>
 							<TableHead className="uppercase">Schedule</TableHead>
+							<TableHead className="uppercase">Host</TableHead>
 							<TableHead className="uppercase">Date & Time</TableHead>
 							<TableHead className="uppercase">Size</TableHead>
 							<TableHead className="uppercase hidden md:table-cell text-right">Duration</TableHead>
@@ -281,6 +282,12 @@ export const SnapshotsTable = ({ snapshots, repositoryId, backups }: Props) => {
 											<span hidden={!!backup} className="text-sm text-muted-foreground">
 												-
 											</span>
+										</div>
+									</TableCell>
+									<TableCell>
+										<div className="flex items-center gap-2">
+											<Monitor className="h-4 w-4 text-muted-foreground" />
+											<span className="text-sm">{snapshot.hostname || "Unknown"}</span>
 										</div>
 									</TableCell>
 									<TableCell>

--- a/app/client/modules/backups/components/snapshot-file-browser.tsx
+++ b/app/client/modules/backups/components/snapshot-file-browser.tsx
@@ -52,7 +52,7 @@ export const SnapshotFileBrowser = (props: Props) => {
 							<CardTitle>File Browser</CardTitle>
 							<CardDescription
 								className={cn({ hidden: !snapshot.time })}
-							>{`Viewing snapshot from ${formatDateTime(snapshot?.time)}`}</CardDescription>
+							>{`Viewing ${snapshot.hostname ? `${snapshot.hostname} from ` : "snapshot from "}${formatDateTime(snapshot.time)}`}</CardDescription>
 						</div>
 						<div className="flex gap-2 flex-wrap sm:flex-nowrap">
 							<Link

--- a/app/client/modules/backups/components/snapshot-file-browser.tsx
+++ b/app/client/modules/backups/components/snapshot-file-browser.tsx
@@ -45,7 +45,7 @@ export const SnapshotFileBrowser = (props: Props) => {
 
 	return (
 		<div className="space-y-4">
-			<Card className="h-150 flex flex-col">
+			<Card className="h-150 flex flex-col pb-0">
 				<CardHeader>
 					<div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4">
 						<div>

--- a/app/client/modules/repositories/routes/restore-snapshot.tsx
+++ b/app/client/modules/repositories/routes/restore-snapshot.tsx
@@ -1,5 +1,5 @@
 import { RestoreForm } from "~/client/components/restore-form";
-import type { Repository } from "~/client/lib/types";
+import type { Repository, Snapshot } from "~/client/lib/types";
 
 type Props = {
 	repository: Repository;
@@ -9,6 +9,7 @@ type Props = {
 	displayBasePath?: string;
 	hasNonPosixSnapshotPaths?: boolean;
 	volumeReadOnly?: boolean;
+	snapshot?: Snapshot;
 };
 
 export function RestoreSnapshotPage(props: Props) {
@@ -20,6 +21,7 @@ export function RestoreSnapshotPage(props: Props) {
 		displayBasePath,
 		hasNonPosixSnapshotPaths,
 		volumeReadOnly,
+		snapshot,
 	} = props;
 
 	return (
@@ -32,6 +34,7 @@ export function RestoreSnapshotPage(props: Props) {
 			displayBasePath={displayBasePath}
 			hasNonPosixSnapshotPaths={hasNonPosixSnapshotPaths}
 			volumeReadOnly={volumeReadOnly}
+			snapshot={snapshot}
 		/>
 	);
 }

--- a/app/client/modules/repositories/routes/restore-snapshot.tsx
+++ b/app/client/modules/repositories/routes/restore-snapshot.tsx
@@ -1,40 +1,8 @@
 import { RestoreForm } from "~/client/components/restore-form";
-import type { Repository, Snapshot } from "~/client/lib/types";
+import type { ComponentProps } from "react";
 
-type Props = {
-	repository: Repository;
-	snapshotId: string;
-	returnPath: string;
-	queryBasePath?: string;
-	displayBasePath?: string;
-	hasNonPosixSnapshotPaths?: boolean;
-	volumeReadOnly?: boolean;
-	snapshot?: Snapshot;
-};
+type Props = ComponentProps<typeof RestoreForm>;
 
 export function RestoreSnapshotPage(props: Props) {
-	const {
-		returnPath,
-		snapshotId,
-		repository,
-		queryBasePath,
-		displayBasePath,
-		hasNonPosixSnapshotPaths,
-		volumeReadOnly,
-		snapshot,
-	} = props;
-
-	return (
-		<RestoreForm
-			key={`${repository.shortId}:${snapshotId}`}
-			repository={repository}
-			snapshotId={snapshotId}
-			returnPath={returnPath}
-			queryBasePath={queryBasePath}
-			displayBasePath={displayBasePath}
-			hasNonPosixSnapshotPaths={hasNonPosixSnapshotPaths}
-			volumeReadOnly={volumeReadOnly}
-			snapshot={snapshot}
-		/>
-	);
+	return <RestoreForm key={`${props.repository.shortId}:${props.snapshot.short_id}`} {...props} />;
 }

--- a/app/client/modules/repositories/tabs/__tests__/snapshots.test.tsx
+++ b/app/client/modules/repositories/tabs/__tests__/snapshots.test.tsx
@@ -1,0 +1,73 @@
+import { afterEach, expect, test, vi } from "vitest";
+import { createMemoryHistory, createRootRoute, createRouter, RouterProvider } from "@tanstack/react-router";
+import { fromPartial } from "@total-typescript/shoehorn";
+import { cleanup, render, screen, userEvent, within } from "~/test/test-utils";
+import { HttpResponse, http, server } from "~/test/msw/server";
+import type { Snapshot } from "~/client/lib/types";
+import { RepositorySnapshotsTabContent } from "../snapshots";
+
+afterEach(() => {
+	cleanup();
+	vi.unstubAllGlobals();
+});
+
+test("filters a host named all, combines text search, and clears both filters", async () => {
+	vi.stubGlobal(
+		"EventSource",
+		class extends EventTarget {
+			close() {}
+		},
+	);
+	const snapshots: Snapshot[] = ["all", "other", ""].map((hostname, index) => ({
+		short_id: `snap-${index}`,
+		hostname,
+		time: Date.UTC(2026, 8, 9),
+		paths: ["/data"],
+		size: 1024,
+		duration: 1000,
+		tags: [],
+		retentionCategories: [],
+	}));
+
+	server.use(
+		http.get("/api/v1/repositories/repo-1/snapshots", () => HttpResponse.json(snapshots)),
+		http.get("/api/v1/backups", () => HttpResponse.json([])),
+		http.get("/api/v1/tasks", () => HttpResponse.json([])),
+	);
+
+	const route = createRootRoute({
+		component: () => (
+			<RepositorySnapshotsTabContent
+				repository={fromPartial({ shortId: "repo-1", name: "Repository", status: "healthy" })}
+				initialSnapshots={snapshots}
+				initialBackupSchedules={[]}
+			/>
+		),
+	});
+
+	const router = createRouter({ routeTree: route, history: createMemoryHistory({ initialEntries: ["/"] }) });
+	render(<RouterProvider router={router} />, { withSuspense: true });
+
+	await screen.findByText("snap-0");
+	await userEvent.click(screen.getByRole("combobox", { name: "Filter snapshots by host" }));
+	await userEvent.click(screen.getByRole("option", { name: /^all$/ }));
+
+	expect(screen.getByText("snap-0")).toBeTruthy();
+	expect(screen.queryByText("snap-1")).toBeNull();
+
+	await userEvent.type(screen.getByPlaceholderText("Search snapshots..."), "snap-1");
+
+	expect(screen.getByText("No snapshots match your filters.")).toBeTruthy();
+
+	await userEvent.click(screen.getByRole("button", { name: "Clear filters" }));
+	const table = await screen.findByRole("table");
+
+	expect(within(table).getByText("snap-0")).toBeTruthy();
+	expect(within(table).getByText("snap-1")).toBeTruthy();
+
+	await userEvent.click(screen.getByRole("combobox", { name: "Filter snapshots by host" }));
+	await userEvent.click(screen.getByRole("option", { name: "Unknown" }));
+
+	expect(screen.getByText("snap-2")).toBeTruthy();
+	expect(screen.queryByText("snap-0")).toBeNull();
+});

--- a/app/client/modules/repositories/tabs/snapshots.tsx
+++ b/app/client/modules/repositories/tabs/snapshots.tsx
@@ -10,6 +10,7 @@ import { SnapshotsTable } from "~/client/components/snapshots-table";
 import { Button } from "~/client/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "~/client/components/ui/card";
 import { Input } from "~/client/components/ui/input";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "~/client/components/ui/select";
 import { Table, TableBody, TableCell, TableRow } from "~/client/components/ui/table";
 import type { BackupSchedule, Repository, Snapshot } from "~/client/lib/types";
 import { toast } from "sonner";
@@ -22,6 +23,7 @@ type Props = {
 
 export const RepositorySnapshotsTabContent = ({ repository, initialSnapshots, initialBackupSchedules }: Props) => {
 	const [searchQuery, setSearchQuery] = useState("");
+	const [selectedHost, setSelectedHost] = useState("all");
 
 	const { data, isPending, failureReason } = useQuery({
 		...listSnapshotsOptions({ path: { shortId: repository.shortId } }),
@@ -48,8 +50,12 @@ export const RepositorySnapshotsTabContent = ({ repository, initialSnapshots, in
 	};
 
 	const snapshots = data ?? [];
+	const hosts = Array.from(
+		new Set(snapshots.map((snapshot) => snapshot.hostname).filter((hostname): hostname is string => !!hostname)),
+	).sort((a, b) => a.localeCompare(b));
 
 	const filteredSnapshots = snapshots.filter((snapshot: Snapshot) => {
+		if (selectedHost !== "all" && snapshot.hostname !== selectedHost) return false;
 		if (!searchQuery) return true;
 		const searchLower = searchQuery.toLowerCase();
 
@@ -139,13 +145,26 @@ export const RepositorySnapshotsTabContent = ({ repository, initialSnapshots, in
 							Backup snapshots stored in this repository. Total: {snapshots.length}
 						</CardDescription>
 					</div>
-					<div className="flex gap-2 items-center">
+					<div className="flex flex-col sm:flex-row gap-2 sm:items-center">
 						<Input
 							className="w-full lg:w-60"
 							placeholder="Search snapshots..."
 							value={searchQuery}
 							onChange={(e) => setSearchQuery(e.target.value)}
 						/>
+						<Select value={selectedHost} onValueChange={setSelectedHost}>
+							<SelectTrigger className="w-full sm:w-48" aria-label="Filter snapshots by host">
+								<SelectValue placeholder="All hosts" />
+							</SelectTrigger>
+							<SelectContent>
+								<SelectItem value="all">All hosts</SelectItem>
+								{hosts.map((host) => (
+									<SelectItem key={host} value={host}>
+										{host}
+									</SelectItem>
+								))}
+							</SelectContent>
+						</Select>
 						<Button
 							onClick={handleRefresh}
 							variant="outline"
@@ -161,12 +180,19 @@ export const RepositorySnapshotsTabContent = ({ repository, initialSnapshots, in
 				<Table className="border-t">
 					<TableBody>
 						<TableRow>
-							<TableCell colSpan={5} className="text-center py-12">
+							<TableCell colSpan={7} className="text-center py-12">
 								<div className="flex flex-col items-center gap-3">
-									<p className="text-muted-foreground">No snapshots match your search.</p>
-									<Button onClick={() => setSearchQuery("")} variant="outline" size="sm">
+									<p className="text-muted-foreground">No snapshots match your filters.</p>
+									<Button
+										onClick={() => {
+											setSearchQuery("");
+											setSelectedHost("all");
+										}}
+										variant="outline"
+										size="sm"
+									>
 										<X className="h-4 w-4 mr-2" />
-										Clear search
+										Clear filters
 									</Button>
 								</div>
 							</TableCell>

--- a/app/client/modules/repositories/tabs/snapshots.tsx
+++ b/app/client/modules/repositories/tabs/snapshots.tsx
@@ -23,7 +23,7 @@ type Props = {
 
 export const RepositorySnapshotsTabContent = ({ repository, initialSnapshots, initialBackupSchedules }: Props) => {
 	const [searchQuery, setSearchQuery] = useState("");
-	const [selectedHost, setSelectedHost] = useState("all");
+	const [selectedHost, setSelectedHost] = useState<string | null>(null);
 
 	const { data, isPending, failureReason } = useQuery({
 		...listSnapshotsOptions({ path: { shortId: repository.shortId } }),
@@ -50,12 +50,12 @@ export const RepositorySnapshotsTabContent = ({ repository, initialSnapshots, in
 	};
 
 	const snapshots = data ?? [];
-	const hosts = Array.from(
-		new Set(snapshots.map((snapshot) => snapshot.hostname).filter((hostname): hostname is string => !!hostname)),
-	).sort((a, b) => a.localeCompare(b));
+	const hosts = Array.from(new Set(snapshots.map((snapshot) => snapshot.hostname))).sort((a, b) =>
+		a.localeCompare(b),
+	);
 
 	const filteredSnapshots = snapshots.filter((snapshot: Snapshot) => {
-		if (selectedHost !== "all" && snapshot.hostname !== selectedHost) return false;
+		if (selectedHost !== null && snapshot.hostname !== selectedHost) return false;
 		if (!searchQuery) return true;
 		const searchLower = searchQuery.toLowerCase();
 
@@ -152,15 +152,18 @@ export const RepositorySnapshotsTabContent = ({ repository, initialSnapshots, in
 							value={searchQuery}
 							onChange={(e) => setSearchQuery(e.target.value)}
 						/>
-						<Select value={selectedHost} onValueChange={setSelectedHost}>
+						<Select
+							value={selectedHost === null ? "all" : `host:${selectedHost}`}
+							onValueChange={(value) => setSelectedHost(value === "all" ? null : value.slice(5))}
+						>
 							<SelectTrigger className="w-full sm:w-48" aria-label="Filter snapshots by host">
 								<SelectValue placeholder="All hosts" />
 							</SelectTrigger>
 							<SelectContent>
 								<SelectItem value="all">All hosts</SelectItem>
 								{hosts.map((host) => (
-									<SelectItem key={host} value={host}>
-										{host}
+									<SelectItem key={host} value={`host:${host}`}>
+										{host || "Unknown"}
 									</SelectItem>
 								))}
 							</SelectContent>
@@ -186,7 +189,7 @@ export const RepositorySnapshotsTabContent = ({ repository, initialSnapshots, in
 									<Button
 										onClick={() => {
 											setSearchQuery("");
-											setSelectedHost("all");
+											setSelectedHost(null);
 										}}
 										variant="outline"
 										size="sm"

--- a/app/routes/(dashboard)/backups/$backupId/$snapshotId.restore.tsx
+++ b/app/routes/(dashboard)/backups/$backupId/$snapshotId.restore.tsx
@@ -68,7 +68,7 @@ export const Route = createFileRoute("/(dashboard)/backups/$backupId/$snapshotId
 
 function RouteComponent() {
 	const { backupId, snapshotId } = Route.useParams();
-	const { repository, queryBasePath, displayBasePath, hasNonPosixSnapshotPaths, volumeReadOnly } =
+	const { snapshot, repository, queryBasePath, displayBasePath, hasNonPosixSnapshotPaths, volumeReadOnly } =
 		Route.useLoaderData();
 
 	return (
@@ -80,6 +80,7 @@ function RouteComponent() {
 			displayBasePath={displayBasePath}
 			hasNonPosixSnapshotPaths={hasNonPosixSnapshotPaths}
 			volumeReadOnly={volumeReadOnly}
+			snapshot={snapshot}
 		/>
 	);
 }

--- a/app/routes/(dashboard)/backups/$backupId/$snapshotId.restore.tsx
+++ b/app/routes/(dashboard)/backups/$backupId/$snapshotId.restore.tsx
@@ -67,14 +67,13 @@ export const Route = createFileRoute("/(dashboard)/backups/$backupId/$snapshotId
 });
 
 function RouteComponent() {
-	const { backupId, snapshotId } = Route.useParams();
+	const { backupId } = Route.useParams();
 	const { snapshot, repository, queryBasePath, displayBasePath, hasNonPosixSnapshotPaths, volumeReadOnly } =
 		Route.useLoaderData();
 
 	return (
 		<RestoreSnapshotPage
 			returnPath={`/backups/${backupId}`}
-			snapshotId={snapshotId}
 			repository={repository}
 			queryBasePath={queryBasePath}
 			displayBasePath={displayBasePath}

--- a/app/routes/(dashboard)/repositories/$repositoryId/$snapshotId/restore.tsx
+++ b/app/routes/(dashboard)/repositories/$repositoryId/$snapshotId/restore.tsx
@@ -72,7 +72,7 @@ export const Route = createFileRoute("/(dashboard)/repositories/$repositoryId/$s
 
 function RouteComponent() {
 	const { repositoryId, snapshotId } = Route.useParams();
-	const { repository, queryBasePath, displayBasePath, hasNonPosixSnapshotPaths, volumeReadOnly } =
+	const { snapshot, repository, queryBasePath, displayBasePath, hasNonPosixSnapshotPaths, volumeReadOnly } =
 		Route.useLoaderData();
 
 	return (
@@ -84,6 +84,7 @@ function RouteComponent() {
 			displayBasePath={displayBasePath}
 			hasNonPosixSnapshotPaths={hasNonPosixSnapshotPaths}
 			volumeReadOnly={volumeReadOnly}
+			snapshot={snapshot}
 		/>
 	);
 }

--- a/app/routes/(dashboard)/repositories/$repositoryId/$snapshotId/restore.tsx
+++ b/app/routes/(dashboard)/repositories/$repositoryId/$snapshotId/restore.tsx
@@ -79,7 +79,6 @@ function RouteComponent() {
 		<RestoreSnapshotPage
 			returnPath={`/repositories/${repositoryId}/${snapshotId}`}
 			repository={repository}
-			snapshotId={snapshotId}
 			queryBasePath={queryBasePath}
 			displayBasePath={displayBasePath}
 			hasNonPosixSnapshotPaths={hasNonPosixSnapshotPaths}

--- a/app/server/modules/repositories/__tests__/repositories.controller.test.ts
+++ b/app/server/modules/repositories/__tests__/repositories.controller.test.ts
@@ -266,6 +266,30 @@ describe("repositories security", () => {
 	});
 });
 
+describe("list snapshots", () => {
+	test("includes each snapshot hostname", async () => {
+		vi.spyOn(repositoriesService, "listSnapshots").mockResolvedValue([
+			{
+				id: "snapshot-id",
+				short_id: "snapshot",
+				time: "2026-09-09T13:30:00Z",
+				paths: ["/var/lib/zerobyte/volumes/data"],
+				hostname: "zerobyte",
+			},
+		]);
+		vi.spyOn(repositoriesService, "getRetentionCategories").mockResolvedValue(new Map());
+
+		const response = await app.request("/api/v1/repositories/test-repo/snapshots", {
+			headers: session.headers,
+		});
+
+		expect(response.status).toBe(200);
+		await expect(response.json()).resolves.toEqual([
+			expect.objectContaining({ short_id: "snapshot", hostname: "zerobyte" }),
+		]);
+	});
+});
+
 describe("repositories updates", () => {
 	test("PATCH updates full config and metadata using shortId", async () => {
 		const repository = await createRepositoryRecord(session.organizationId);

--- a/app/server/modules/repositories/repositories.controller.ts
+++ b/app/server/modules/repositories/repositories.controller.ts
@@ -132,6 +132,7 @@ export const repositoriesController = new Hono()
 
 			return {
 				short_id: snapshot.short_id,
+				hostname: snapshot.hostname,
 				duration,
 				paths: snapshot.paths,
 				tags: snapshot.tags ?? [],

--- a/app/server/modules/repositories/repositories.dto.ts
+++ b/app/server/modules/repositories/repositories.dto.ts
@@ -204,7 +204,7 @@ const snapshotSchema = z.object({
 	duration: z.number(),
 	tags: z.array(z.string()),
 	retentionCategories: z.array(z.string()),
-	hostname: z.string().optional(),
+	hostname: z.string(),
 	summary: resticSnapshotSummarySchema.optional(),
 });
 

--- a/app/server/modules/repositories/repositories.service.ts
+++ b/app/server/modules/repositories/repositories.service.ts
@@ -336,7 +336,7 @@ const listSnapshotFiles = async (
 			hostname: string;
 			paths: string[];
 		} | null;
-		nodes: { name: string; type: string; path: string; size?: number; mode?: number }[];
+		nodes: { name: string; type: string; path: string; size?: number; mode?: number; mtime?: string }[];
 		pagination: { offset: number; limit: number; total: number; hasMore: boolean };
 	};
 	const cached = cache.get<LsResult>(cacheKey);

--- a/app/server/modules/repositories/repositories.service.ts
+++ b/app/server/modules/repositories/repositories.service.ts
@@ -328,17 +328,7 @@ const listSnapshotFiles = async (
 	const limit = options?.limit ?? 500;
 
 	const cacheKey = cacheKeys.repository.ls(repository.id, snapshotId, path, offset, limit);
-	type LsResult = {
-		snapshot: {
-			id: string;
-			short_id: string;
-			time: string;
-			hostname: string;
-			paths: string[];
-		} | null;
-		nodes: { name: string; type: string; path: string; size?: number; mode?: number; mtime?: string }[];
-		pagination: { offset: number; limit: number; total: number; hasMore: boolean };
-	};
+	type LsResult = Effect.Effect.Success<ReturnType<typeof restic.ls>>;
 	const cached = cache.get<LsResult>(cacheKey);
 	if (cached?.snapshot) {
 		return {


### PR DESCRIPTION
## Summary

Improve snapshot discovery and restore confidence for repositories containing backups from multiple hosts.

This PR makes host information visible throughout the snapshot workflow and adds file metadata inspection to the shared snapshot browser.

Closes https://github.com/nicotsx/zerobyte/issues/1098

## Changes

### Snapshot navigation

- Add a hostname filter to the repository snapshots view.
- Populate the filter from the hostnames available in the loaded snapshots.
- Allow hostname filtering and text search to be used together.
- Add a dedicated Host column to the snapshots table.
- Update the empty state so users can clear all active filters at once.

### Snapshot context

- Show the snapshot hostname and creation date in the file browser header.
- Show repository, snapshot ID, hostname, and creation date on restore pages.
- Apply the restore context consistently whether users arrive through a repository or a backup job.

### File attributes

- Allow files and directories to be selected independently from restore checkboxes.
- Display a metadata panel for the selected snapshot entry.
- Show the entry path, type, size, modification time, and POSIX permissions when available.
- Preserve the existing compact tree layout and existing restore-selection behavior.
- Extend the shared file-entry model and cached snapshot file response typing to retain modification time and permissions returned by Restic.

<img width="1513" height="542" alt="image" src="https://github.com/user-attachments/assets/f2706ef7-7da5-4852-aff4-b4ee4614c09a" />

<img width="1577" height="1039" alt="image" src="https://github.com/user-attachments/assets/c0479e77-142c-41ee-ae82-cca646f685d2" />

<img width="1547" height="895" alt="image" src="https://github.com/user-attachments/assets/d58c2b91-0d4c-4f99-b8d0-0db3549e72bb" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added hostname display to snapshot listings and restore views.
  - Added host-based filtering for repository snapshots, including an “Unknown” option.
  - Added detailed information for selected snapshot files, including path, size, date, and permissions.
  - Improved snapshot file browsing with accurate directory metadata and selection details.

- **Bug Fixes**
  - Snapshot restore flows now consistently use complete snapshot information.
  - Snapshot list responses reliably include hostname data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->