### PR TITLE
fix(desktop): pin localhost TLS certificates

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -79,6 +79,21 @@ jobs:
         shell: bash
         run: bun run test:client
 
+  test-desktop:
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 1
+
+      - name: Install dependencies
+        uses: "./.github/actions/install-dependencies"
+
+      - name: Run desktop tests
+        run: bun run test:desktop
+
   build:
     timeout-minutes: 15
     runs-on: ubuntu-latest

--- a/apps/desktop/electron/__tests__/desktop-security.test.ts
+++ b/apps/desktop/electron/__tests__/desktop-security.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, expect, test, vi } from "vitest";
+import { fromPartial } from "@total-typescript/shoehorn";
+import { createPrivateKey, X509Certificate } from "node:crypto";
+import { createDesktopTls } from "../desktop-tls";
+import { createDesktopSession, launchSecretHeader } from "../desktop-session";
+
+const { setCertificateVerifyProc, desktopFetch } = vi.hoisted(() => ({
+	setCertificateVerifyProc: vi.fn<Electron.Session["setCertificateVerifyProc"]>(),
+	desktopFetch: vi.fn<Electron.Session["fetch"]>(),
+}));
+
+vi.mock("electron", () => ({
+	app: { getLocale: () => "en-GB" },
+	session: {
+		defaultSession: {
+			setCertificateVerifyProc,
+			fetch: desktopFetch,
+		},
+	},
+}));
+
+afterEach(() => vi.resetAllMocks());
+
+test("trusts only this launch's certificate for loopback, even when another certificate is CA-trusted", async () => {
+	const first = await createDesktopTls();
+	const second = await createDesktopTls();
+	const certificate = new X509Certificate(second.cert);
+	expect(certificate.checkIP("127.0.0.1")).toBe("127.0.0.1");
+	expect(certificate.checkPrivateKey(createPrivateKey(second.key))).toBe(true);
+	expect(second.cert).not.toBe(first.cert);
+
+	const verify = setCertificateVerifyProc.mock.calls[1][0];
+	expect(verify).toBeTypeOf("function");
+	if (!verify) throw new Error("Missing certificate verifier");
+
+	for (const [data, result] of [
+		[second.cert, 0],
+		[first.cert, -2],
+		["invalid certificate", -2],
+	] as const) {
+		const callback = vi.fn();
+		verify(
+			fromPartial({
+				hostname: "127.0.0.1",
+				certificate: { data },
+				verificationResult: "OK",
+				isIssuedByKnownRoot: true,
+			}),
+			callback,
+		);
+		expect(callback).toHaveBeenCalledExactlyOnceWith(result);
+	}
+
+	const callback = vi.fn();
+	verify(fromPartial({ hostname: "example.com", certificate: { data: second.cert } }), callback);
+	expect(callback).toHaveBeenCalledExactlyOnceWith(-3);
+});
+
+test("creates the session through the pinned Electron session with explicit cookie-jar credentials", async () => {
+	desktopFetch.mockResolvedValue(
+		new Response("{}", {
+			headers: { "Set-Cookie": "zerobyte.session_token=test-token; HttpOnly; Secure; Path=/" },
+		}),
+	);
+	const url = "https://127.0.0.1:12345";
+	const result = await createDesktopSession(url, "test-launch-secret");
+
+	expect(result).toBeUndefined();
+	expect(desktopFetch).toHaveBeenCalledExactlyOnceWith(
+		`${url}/api/v1/desktop/session`,
+		expect.objectContaining({
+			method: "POST",
+			credentials: "include",
+			redirect: "error",
+			headers: expect.objectContaining({ [launchSecretHeader]: "test-launch-secret" }),
+		}),
+	);
+});
+
+test("rejects plaintext bootstrap URLs before sending the launch secret", async () => {
+	await expect(createDesktopSession("http://127.0.0.1:12345", "test-launch-secret")).rejects.toThrow("HTTPS");
+	expect(desktopFetch).not.toHaveBeenCalled();
+});
+
+test("fails bootstrap without installing cookies when the pinned connection fails", async () => {
+	desktopFetch.mockRejectedValue(new Error("Certificate rejected"));
+	await expect(createDesktopSession("https://127.0.0.1:12345", "test-launch-secret")).rejects.toThrow(
+		"Certificate rejected",
+	);
+});

--- a/apps/desktop/electron/__tests__/desktop-session.electron.ts
+++ b/apps/desktop/electron/__tests__/desktop-session.electron.ts
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { once } from "node:events";
+import https from "node:https";
+import os from "node:os";
+import path from "node:path";
+import { app, session } from "electron";
+import { createDesktopTls } from "../desktop-tls";
+import { createDesktopSession } from "../desktop-session";
+
+const userData = mkdtempSync(path.join(os.tmpdir(), "zerobyte-session-"));
+app.setPath("userData", userData);
+
+void app.whenReady().then(async () => {
+	const server = https.createServer(await createDesktopTls(), (request, response) => {
+		if (request.url === "/api/v1/desktop/session") {
+			assert.equal(request.headers["x-zerobyte-desktop-launch-secret"], "test-secret");
+			response.setHeader(
+				"Set-Cookie",
+				"__Secure-session=initial; Path=/; Secure; HttpOnly; SameSite=Strict; Max-Age=3600",
+			);
+		} else if (request.url === "/rotate") {
+			assert.equal(request.headers.cookie, "__Secure-session=initial");
+			response.setHeader(
+				"Set-Cookie",
+				"__Secure-session=rotated; Path=/; Secure; HttpOnly; SameSite=Strict; Max-Age=3600",
+			);
+		} else {
+			assert.equal(request.headers.cookie, "__Secure-session=rotated");
+		}
+
+		response.end("{}");
+	});
+
+	try {
+		server.listen(0, "127.0.0.1");
+
+		await once(server, "listening");
+		const address = server.address();
+
+		assert(address && typeof address === "object");
+
+		const url = `https://127.0.0.1:${address.port}`;
+
+		assert.equal(await createDesktopSession(url, "test-secret"), undefined);
+
+		const [cookie] = await session.defaultSession.cookies.get({ url });
+
+		assert(cookie);
+		assert.equal(cookie.httpOnly, true);
+		assert.equal(cookie.secure, true);
+		assert.equal(cookie.sameSite, "strict");
+		assert(cookie.expirationDate && cookie.expirationDate > Date.now() / 1000 + 3500);
+
+		for (const route of ["/rotate", "/authenticated"]) {
+			const response = await session.defaultSession.fetch(url + route, {
+				credentials: "include",
+				redirect: "error",
+			});
+			assert.equal(response.status, 200);
+			await response.text();
+		}
+
+		console.info("PASS: Electron bootstrap retains cookie attributes and forwards updated cookies");
+	} catch (error) {
+		console.error(error);
+		process.exitCode = 1;
+	} finally {
+		await session.defaultSession.closeAllConnections();
+
+		server.closeAllConnections();
+		await new Promise<void>((resolve) => server.close(() => resolve()));
+
+		rmSync(userData, { recursive: true, force: true });
+		app.exit(Number(process.exitCode ?? 0));
+	}
+});

--- a/apps/desktop/electron/desktop-runtime.ts
+++ b/apps/desktop/electron/desktop-runtime.ts
@@ -1,10 +1,11 @@
-import { app } from "electron";
+import { app, session } from "electron";
 import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
 import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import net from "node:net";
 import path from "node:path";
 import { toMessage } from "@zerobyte/core/utils";
+import { createDesktopTls } from "./desktop-tls";
 
 type DesktopDirs = {
 	dataDir: string;
@@ -132,8 +133,12 @@ const waitForServer = async (serverUrl: string, serverProcess: ChildProcessWitho
 		throwIfExited(serverProcess);
 
 		try {
-			const response = await fetch(`${serverUrl}/api/healthcheck`, { signal: AbortSignal.timeout(5_000) });
+			const response = await session.defaultSession.fetch(`${serverUrl}/api/healthcheck`, {
+				signal: AbortSignal.timeout(5_000),
+				redirect: "error",
+			});
 			if (response.ok) {
+				throwIfExited(serverProcess);
 				return;
 			}
 			lastError = `${response.status} ${response.statusText}`;
@@ -152,13 +157,19 @@ export const startDesktopRuntime = async (
 ): Promise<DesktopRuntime> => {
 	const port = await getAvailablePort();
 	const dirs = await ensureDesktopDirs();
-	const url = `http://127.0.0.1:${port}`;
+	const url = `https://127.0.0.1:${port}`;
 	const launchSecret = crypto.randomBytes(32).toString("hex");
+	const tls = await createDesktopTls();
 	let stopped = false;
 	let command = "bunx";
 	let args = ["--bun", "vite", "--host", "127.0.0.1", "--port", String(port), "--strictPort"];
 	let cwd = process.env.ZEROBYTE_REPO_ROOT ?? path.resolve(process.cwd(), "../..");
-	const env = { ...createServerEnv(port, dirs, url, launchSecret), NODE_ENV: "development" };
+	const env = {
+		...createServerEnv(port, dirs, url, launchSecret),
+		NODE_ENV: "development",
+		NITRO_SSL_CERT: tls.cert,
+		NITRO_SSL_KEY: tls.key,
+	};
 
 	if (app.isPackaged) {
 		const binDir = path.join(dirs.resourcesDir, "bin");

--- a/apps/desktop/electron/desktop-session.ts
+++ b/apps/desktop/electron/desktop-session.ts
@@ -4,8 +4,15 @@ import { inferDateTimePreferences } from "@zerobyte/core/utils";
 export const launchSecretHeader = "X-Zerobyte-Desktop-Launch-Secret";
 
 export const createDesktopSession = async (serverUrl: string, launchSecret: string) => {
-	const response = await fetch(`${serverUrl}/api/v1/desktop/session`, {
+	if (new URL(serverUrl).protocol !== "https:") {
+		throw new Error("Desktop sessions require HTTPS");
+	}
+
+	const response = await session.defaultSession.fetch(`${serverUrl}/api/v1/desktop/session`, {
 		method: "POST",
+		credentials: "include",
+		redirect: "error",
+		signal: AbortSignal.timeout(10_000),
 		headers: {
 			[launchSecretHeader]: launchSecret,
 			"Content-Type": "application/json",
@@ -16,26 +23,4 @@ export const createDesktopSession = async (serverUrl: string, launchSecret: stri
 	if (!response.ok) {
 		throw new Error(`Desktop session failed: ${await response.text()}`);
 	}
-
-	const authCookies = response.headers
-		.getSetCookie()
-		.map((cookie) => cookie.split(";")[0])
-		.filter(Boolean);
-
-	for (const cookie of authCookies) {
-		const [name, ...valueParts] = cookie.split("=");
-		const value = valueParts.join("=");
-		if (name && value) {
-			await session.defaultSession.cookies.set({
-				url: serverUrl,
-				name,
-				value,
-				path: "/",
-				httpOnly: true,
-				sameSite: "lax",
-			});
-		}
-	}
-
-	return authCookies.join("; ");
 };

--- a/apps/desktop/electron/desktop-tls.ts
+++ b/apps/desktop/electron/desktop-tls.ts
@@ -1,0 +1,34 @@
+import { session } from "electron";
+import { KeyObject, randomBytes, X509Certificate } from "node:crypto";
+import { SubjectAlternativeNameExtension, X509CertificateGenerator } from "@peculiar/x509";
+
+export const createDesktopTls = async () => {
+	const algorithm = { name: "ECDSA", namedCurve: "P-256", hash: "SHA-256" };
+	const keys = await crypto.subtle.generateKey(algorithm, true, ["sign", "verify"]);
+	const certificate = await X509CertificateGenerator.createSelfSigned({
+		serialNumber: randomBytes(16).toString("hex"),
+		name: "CN=Zerobyte Desktop",
+		notBefore: new Date(Date.now() - 60_000),
+		notAfter: new Date(Date.now() + 365 * 24 * 60 * 60 * 1000),
+		signingAlgorithm: algorithm,
+		keys,
+		extensions: [new SubjectAlternativeNameExtension([{ type: "ip", value: "127.0.0.1" }])],
+	});
+	const cert = certificate.toString("pem");
+	const expected = new X509Certificate(cert);
+
+	session.defaultSession.setCertificateVerifyProc(({ hostname, certificate }, callback) => {
+		if (hostname !== "127.0.0.1") {
+			callback(-3); // Use Chromium's normal verification for other hosts.
+			return;
+		}
+
+		try {
+			callback(new X509Certificate(certificate.data).raw.equals(expected.raw) ? 0 : -2);
+		} catch {
+			callback(-2);
+		}
+	});
+
+	return { cert, key: KeyObject.from(keys.privateKey).export({ type: "pkcs8", format: "pem" }) };
+};

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -1,4 +1,14 @@
-import { app, BrowserWindow, dialog, ipcMain, Menu, nativeTheme, type OpenDialogOptions, type Tray } from "electron";
+import {
+	app,
+	BrowserWindow,
+	dialog,
+	ipcMain,
+	Menu,
+	nativeTheme,
+	session,
+	type OpenDialogOptions,
+	type Tray,
+} from "electron";
 import { toMessage } from "@zerobyte/core/utils";
 import { startDesktopRuntime, type DesktopRuntime } from "./desktop-runtime";
 import { createDesktopSession } from "./desktop-session";
@@ -18,7 +28,6 @@ let mainWindow: BrowserWindow | null = null;
 let trayPopoverWindow: BrowserWindow | null = null;
 let tray: Tray | null = null;
 let runtime: DesktopRuntime | null = null;
-let authCookieHeader: string | null = null;
 let stopAccessingBookmarks: (() => void) | null = null;
 let isQuitting = false;
 let trayStatusTimer: ReturnType<typeof setInterval> | null = null;
@@ -111,15 +120,14 @@ const getTrayPopoverWindow = async () => {
 };
 
 const refreshTrayStatus = async () => {
-	if (!runtime || !tray || !authCookieHeader) {
+	if (!runtime || !tray) {
 		return;
 	}
 
 	try {
-		const response = await fetch(`${runtime.url}/api/v1/backups`, {
-			headers: {
-				cookie: authCookieHeader,
-			},
+		const response = await session.defaultSession.fetch(`${runtime.url}/api/v1/backups`, {
+			redirect: "error",
+			credentials: "include",
 		});
 
 		if (!response.ok) {
@@ -167,7 +175,7 @@ if (!app.requestSingleInstanceLock()) {
 			runtime = await startDesktopRuntime((status) => {
 				dialog.showErrorBox("Zerobyte stopped", `Server process exited with ${status}`);
 			});
-			authCookieHeader = await createDesktopSession(runtime.url, runtime.launchSecret);
+			await createDesktopSession(runtime.url, runtime.launchSecret);
 			setupTray();
 			void refreshTrayStatus();
 			trayStatusTimer = setInterval(() => void refreshTrayStatus(), trayStatusPollMs);
@@ -187,7 +195,6 @@ app.on("before-quit", () => {
 	if (trayStatusTimer) clearInterval(trayStatusTimer);
 	runtime?.stop();
 	runtime = null;
-	authCookieHeader = null;
 	stopAccessingBookmarks?.();
 	stopAccessingBookmarks = null;
 });

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -17,6 +17,7 @@
 		"tsc": "tsc --noEmit"
 	},
 	"dependencies": {
+		"@peculiar/x509": "1.14.3",
 		"@zerobyte/core": "workspace:*"
 	},
 	"devDependencies": {

--- a/bun.lock
+++ b/bun.lock
@@ -133,6 +133,7 @@
       "name": "@zerobyte/desktop",
       "version": "0.0.0",
       "dependencies": {
+        "@peculiar/x509": "1.14.3",
         "@zerobyte/core": "workspace:*",
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
 		"gen:api-client": "NODE_TLS_REJECT_UNAUTHORIZED=0 dotenv -e .env.local -- openapi-ts",
 		"gen:migrations": "dotenv -e .env.local -- drizzle-kit generate",
 		"studio": "drizzle-kit studio",
+		"test:desktop": "bunx --bun vitest run --project desktop",
 		"test:server": "dotenv -e .env.test -- bunx --bun vitest run --project server",
 		"test:client": "dotenv -e .env.test -- bunx --bun vitest run --project client",
 		"test": "dotenv -e .env.test -- bunx --bun vitest run && vp run -F './apps/*' -F './packages/*' test",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -41,6 +41,10 @@ export default defineConfig({
 	server: {
 		host: "0.0.0.0",
 		port: 3000,
+		https:
+			process.env.ZEROBYTE_RUNTIME === "desktop"
+				? { cert: process.env.NITRO_SSL_CERT, key: process.env.NITRO_SSL_KEY }
+				: undefined,
 		allowedHosts: [".ts.net"],
 	},
 	run: {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -17,6 +17,14 @@ export default defineConfig({
 			{
 				extends: true,
 				test: {
+					name: "desktop",
+					environment: "node",
+					include: ["apps/desktop/electron/**/*.test.ts"],
+				},
+			},
+			{
+				extends: true,
+				test: {
 					name: "server",
 					environment: "node",
 					include: ["app/**/*.test.ts", "app/**/*.test.tsx", "app/**/*.spec.ts", "app/**/*.spec.tsx"],


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Desktop connections now use HTTPS with a per-launch certificate trusted only for the local desktop server.
  * Session authentication is handled securely through Electron’s cookie management, including secure cookie attributes and credentialed requests.
  * Redirects, plaintext connection attempts, and failed server connections are rejected.

* **Reliability**
  * Desktop health checks now verify both the server response and that the server process remains active.

* **Tests**
  * Added automated coverage for desktop security, session handling, cookie behavior, and authenticated requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->