### PR TITLE
feat: desktop file logging

### DIFF
--- a/apps/agent/src/volume-host/__tests__/operations.test.ts
+++ b/apps/agent/src/volume-host/__tests__/operations.test.ts
@@ -2,12 +2,14 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import type { Volume as AgentVolume } from "@zerobyte/contracts/volumes";
-import { afterEach, expect, test } from "vitest";
+import { afterEach, expect, test, vi } from "vitest";
+import { logger } from "@zerobyte/core/node";
 import { listVolumeFiles } from "../operations";
 
 let tempRoot: string | undefined;
 
 afterEach(async () => {
+	vi.restoreAllMocks();
 	if (tempRoot) {
 		await fs.rm(tempRoot, { recursive: true, force: true });
 		tempRoot = undefined;
@@ -61,6 +63,14 @@ test("listVolumeFiles rejects traversal outside the volume", async () => {
 
 test("listVolumeFiles reports missing directories consistently", async () => {
 	const volume = await createDirectoryVolume();
+	const logError = vi.spyOn(logger, "error").mockImplementation(() => {});
 
 	await expect(listVolumeFiles(volume, "missing", 0, 10)).rejects.toThrow("Directory not found");
+	expect(logError).toHaveBeenCalledWith("Failed to list volume directory", {
+		volumeId: volume.shortId,
+		volumePath: tempRoot,
+		requestedPath: path.join(tempRoot!, "missing"),
+		error: expect.stringContaining("ENOENT"),
+		code: "ENOENT",
+	});
 });

--- a/apps/agent/src/volume-host/operations.ts
+++ b/apps/agent/src/volume-host/operations.ts
@@ -3,6 +3,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import type { BackendConfig, Volume as AgentVolume } from "@zerobyte/contracts/volumes";
 import { toMessage } from "@zerobyte/core/utils";
+import { logger } from "@zerobyte/core/node";
 import { Data, Effect } from "effect";
 import { createVolumeBackend, getVolumePath, isNodeJSErrnoException } from ".";
 
@@ -87,6 +88,13 @@ export const listVolumeFiles = async (
 			hasMore: startOffset + pageSize < total,
 		};
 	} catch (error) {
+		logger.error("Failed to list volume directory", {
+			volumeId: volume.shortId,
+			volumePath,
+			requestedPath,
+			error: toMessage(error),
+			code: isNodeJSErrnoException(error) ? error.code : undefined,
+		});
 		if (isNodeJSErrnoException(error) && error.code === "ENOENT") {
 			throw new Error("Directory not found");
 		}

--- a/apps/desktop/electron/__tests__/desktop-log.test.ts
+++ b/apps/desktop/electron/__tests__/desktop-log.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, expect, test, vi } from "vitest";
+import { mkdtempSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { RotatingLog } from "../rotating-log";
+let desktopLog: typeof import("../desktop-log");
+
+const { getPath } = vi.hoisted(() => ({ getPath: vi.fn() }));
+vi.mock("electron", () => ({ app: { getPath } }));
+
+const directories: string[] = [];
+const setup = async () => {
+	vi.resetModules();
+	desktopLog = await import("../desktop-log");
+	const directory = mkdtempSync(path.join(os.tmpdir(), "zerobyte-desktop-log-"));
+	directories.push(directory);
+	getPath.mockReturnValue(directory);
+	return path.join(desktopLog.getDesktopLogsPath(), "desktop.log");
+};
+
+afterEach(async () => {
+	await desktopLog?.closeDesktopLog();
+	vi.restoreAllMocks();
+	vi.unstubAllEnvs();
+	for (const directory of directories.splice(0)) rmSync(directory, { recursive: true, force: true });
+});
+
+test("persists timestamped output and error details without ANSI codes or launch credentials", async () => {
+	const file = await setup();
+	const { writeDesktopLog, redactDesktopLogSecrets } = desktopLog;
+	vi.stubEnv("NODE_ENV", "production");
+	redactDesktopLogSecrets(
+		"test-launch-secret",
+		"-----BEGIN PRIVATE KEY-----\nprivate-key-material\n-----END PRIVATE KEY-----",
+	);
+	writeDesktopLog("server:stdout", "\u001b[32mready\u001b[0m test-launch-secret password=example");
+	writeDesktopLog("server:stderr", "private-key-material");
+	writeDesktopLog("desktop", new Error("Directory not found: C:\\Users\\test\\Documents"));
+
+	await desktopLog.closeDesktopLog();
+	const content = readFileSync(file, "utf8");
+	expect(content).toMatch(/\d{4}-\d{2}-\d{2}T.*Z \[server:stdout\] ready \[REDACTED\] password=\*\*\*/);
+	expect(content).toContain("[server:stderr] [REDACTED]");
+	expect(content).toContain("Error: Directory not found: C:\\Users\\test\\Documents");
+	expect(content).not.toContain("\u001b");
+	expect(content).not.toContain("test-launch-secret");
+	expect(content).not.toContain("private-key-material");
+	if (process.platform !== "win32") expect(statSync(file).mode & 0o777).toBe(0o600);
+});
+
+test("appends existing logs, rotates in order, and retains one backup", async () => {
+	const file = await setup();
+	const { mkdirSync } = await import("node:fs");
+	mkdirSync(path.dirname(file));
+	writeFileSync(file, "previous launch\n");
+	const sink = new RotatingLog(file, 40);
+	sink.write("next launch\n");
+	await sink.close();
+	expect(readFileSync(file, "utf8")).toBe("previous launch\nnext launch\n");
+	const rotating = new RotatingLog(file, 40);
+	rotating.write("a".repeat(30) + "\n");
+	rotating.write("b".repeat(30) + "\n");
+	rotating.write("c".repeat(30) + "\n");
+	await rotating.close();
+	expect(readFileSync(file, "utf8")).toBe("c".repeat(30) + "\n");
+	expect(readFileSync(file + ".1", "utf8")).toBe("b".repeat(30) + "\n");
+	expect(readdirSync(path.dirname(file)).sort()).toEqual(["desktop.log", "desktop.log.1"]);
+});
+
+test("drops excess output while flushing accepted records in order", async () => {
+	const file = await setup();
+	const sink = new RotatingLog(file, 1024, 20);
+	sink.write("first\n");
+	sink.write("second\n");
+	sink.write("x".repeat(20));
+	sink.write("third\n");
+	await sink.close();
+	const content = readFileSync(file, "utf8");
+	expect(content).toBe("first\nsecond\nthird\n");
+	expect(content).not.toContain("x".repeat(20));
+	sink.write("after close");
+	expect(readFileSync(file, "utf8")).toBe(content);
+});
+
+test("returns before disk initialization completes", async () => {
+	const file = await setup();
+	const sink = new RotatingLog(file);
+	sink.write("queued\n");
+	// No filesystem work has completed in the synchronous stream callback.
+	expect(() => statSync(file)).toThrow();
+	await sink.close();
+	expect(readFileSync(file, "utf8")).toBe("queued\n");
+});
+
+test("a disk failure does not crash the app or reject shutdown", async () => {
+	await setup();
+	const blocker = path.join(getPath(), "blocked");
+	writeFileSync(blocker, "not a directory");
+	const sink = new RotatingLog(path.join(blocker, "desktop.log"));
+	const stderr = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+	sink.write("still running");
+	await expect(sink.close()).resolves.toBeUndefined();
+	expect(stderr).toHaveBeenCalledWith("[zerobyte] Unable to write desktop log\n");
+});
+
+test("omits oversized records", async () => {
+	const file = await setup();
+	desktopLog.writeDesktopLog("server:stdout", "x".repeat(100_000));
+	await desktopLog.closeDesktopLog();
+	expect(statSync(file).size).toBeLessThan(66_000);
+	expect(readFileSync(file, "utf8")).toContain("[oversized log record omitted]");
+});

--- a/apps/desktop/electron/desktop-log.ts
+++ b/apps/desktop/electron/desktop-log.ts
@@ -1,0 +1,45 @@
+import { app } from "electron";
+import path from "node:path";
+import { stripVTControlCharacters } from "node:util";
+import { sanitizeSensitiveData } from "@zerobyte/core/utils";
+import { RotatingLog } from "./rotating-log";
+
+let sink: RotatingLog | undefined;
+const secrets = new Set<string>();
+
+export const getDesktopLogsPath = () => path.join(app.getPath("userData"), "logs");
+
+export const redactDesktopLogSecrets = (...values: string[]) => {
+	for (const value of values) {
+		if (!value) continue;
+
+		secrets.add(value);
+		if (value.includes("\n")) {
+			for (const line of value.split(/\r?\n/)) {
+				if (line) secrets.add(line);
+			}
+		}
+	}
+};
+
+const formatRecord = (source: string, message: unknown) => {
+	let text = message instanceof Error ? (message.stack ?? message.message) : String(message);
+	if (text.length > 64 * 1024) text = "[oversized log record omitted]";
+	text = stripVTControlCharacters(text);
+	for (const secret of secrets) text = text.replaceAll(secret, "[REDACTED]");
+
+	text = sanitizeSensitiveData(text);
+
+	if (text.length > 64 * 1024) text = `${text.slice(0, 64 * 1024)} [truncated]`;
+
+	return `${new Date().toISOString()} [${source}] ${text}\n`;
+};
+
+export const writeDesktopLog = (source: string, message: unknown) => {
+	sink ??= new RotatingLog(path.join(getDesktopLogsPath(), "desktop.log"));
+	sink.write(formatRecord(source, message));
+};
+
+export const closeDesktopLog = async () => {
+	await sink?.close();
+};

--- a/apps/desktop/electron/desktop-runtime.ts
+++ b/apps/desktop/electron/desktop-runtime.ts
@@ -4,8 +4,10 @@ import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import net from "node:net";
 import path from "node:path";
+import { createInterface } from "node:readline";
 import { toMessage } from "@zerobyte/core/utils";
 import { createDesktopTls } from "./desktop-tls";
+import { redactDesktopLogSecrets, writeDesktopLog } from "./desktop-log";
 
 type DesktopDirs = {
 	dataDir: string;
@@ -25,9 +27,6 @@ export type DesktopRuntime = {
 const ownerOnlyDirMode = 0o700;
 const ownerOnlyFileMode = 0o600;
 const desktopAppVersion = import.meta.env.VITE_APP_VERSION;
-if (app.isPackaged && !desktopAppVersion) {
-	throw new Error("Packaged desktop app is missing VITE_APP_VERSION.");
-}
 
 const chmodIfSupported = async (targetPath: string, mode: number) => {
 	if (process.platform !== "win32") {
@@ -114,6 +113,8 @@ const createServerEnv = (port: number, dirs: DesktopDirs, serverUrl: string, lau
 	ZEROBYTE_VOLUMES_DIR: dirs.volumesDir,
 	ENABLE_LOCAL_AGENT: "false",
 	DISABLE_RATE_LIMITING: "true",
+	NO_COLOR: "1",
+	FORCE_COLOR: "0",
 });
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
@@ -155,15 +156,23 @@ const waitForServer = async (serverUrl: string, serverProcess: ChildProcessWitho
 export const startDesktopRuntime = async (
 	onUnexpectedExit: (status: string | number) => void,
 ): Promise<DesktopRuntime> => {
+	if (app.isPackaged && !desktopAppVersion) {
+		throw new Error("Packaged desktop app is missing VITE_APP_VERSION.");
+	}
+
 	const port = await getAvailablePort();
 	const dirs = await ensureDesktopDirs();
 	const url = `https://127.0.0.1:${port}`;
 	const launchSecret = crypto.randomBytes(32).toString("hex");
 	const tls = await createDesktopTls();
+
+	redactDesktopLogSecrets(launchSecret, dirs.appSecret, String(tls.key));
+
 	let stopped = false;
 	let command = "bunx";
 	let args = ["--bun", "vite", "--host", "127.0.0.1", "--port", String(port), "--strictPort"];
 	let cwd = process.env.ZEROBYTE_REPO_ROOT ?? path.resolve(process.cwd(), "../..");
+
 	const env = {
 		...createServerEnv(port, dirs, url, launchSecret),
 		NODE_ENV: "development",
@@ -194,17 +203,23 @@ export const startDesktopRuntime = async (
 	});
 
 	const handleServerExit = (code: number | null, signal: NodeJS.Signals | null) => {
+		writeDesktopLog("server", `Exited: ${signal ?? code ?? "unknown status"}`);
 		if (!stopped) {
 			onUnexpectedExit(signal ?? code ?? "unknown status");
 		}
 	};
 
 	try {
-		serverProcess.stdout.on("data", (data) => process.stdout.write(`[zerobyte] ${data}`));
-		serverProcess.stderr.on("data", (data) => process.stderr.write(`[zerobyte] ${data}`));
+		writeDesktopLog("desktop", `Starting server at ${url}`);
+		for (const source of ["stdout", "stderr"] as const) {
+			createInterface({ input: serverProcess[source] }).on("line", (line) =>
+				writeDesktopLog(`server:${source}`, line),
+			);
+		}
 		serverProcess.once("exit", handleServerExit);
 
 		await waitForServer(url, serverProcess);
+		writeDesktopLog("desktop", "Server ready");
 
 		return {
 			url,

--- a/apps/desktop/electron/desktop-tray.ts
+++ b/apps/desktop/electron/desktop-tray.ts
@@ -1,5 +1,6 @@
-import { app, BrowserWindow, Menu, nativeImage, screen, Tray, type Rectangle } from "electron";
+import { app, BrowserWindow, dialog, Menu, nativeImage, screen, shell, Tray, type Rectangle } from "electron";
 import path from "node:path";
+import { getDesktopLogsPath } from "./desktop-log";
 
 const trayIconFileName = "tray-icon.png";
 const trayIconSize = 18;
@@ -171,6 +172,13 @@ export const createTray = ({ openWindow, togglePopover, quit }: TrayOptions) => 
 		tray.popUpContextMenu(
 			Menu.buildFromTemplate([
 				{ label: "Open Zerobyte", click: openWindow },
+				{
+					label: "Open logs folder",
+					click: async () => {
+						const error = await shell.openPath(getDesktopLogsPath());
+						if (error) dialog.showErrorBox("Could not open logs folder", error);
+					},
+				},
 				{ type: "separator" },
 				{ label: "Quit Zerobyte", click: quit },
 			]),

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -15,6 +15,7 @@ import { createDesktopSession } from "./desktop-session";
 import { createTray, createTrayPopoverWindow, toggleTrayPopover, updateTrayStatus } from "./desktop-tray";
 import { createDesktopWindow } from "./desktop-window";
 import { saveSecurityScopedBookmark, startAccessingSavedBookmarks } from "./security-scoped-bookmarks";
+import { closeDesktopLog, writeDesktopLog } from "./desktop-log";
 
 const trayStatusPollMs = 30_000;
 
@@ -153,6 +154,7 @@ const setupTray = () => {
 			void getTrayPopoverWindow()
 				.then((window) => toggleTrayPopover(window, bounds))
 				.catch((error) => {
+					writeDesktopLog("desktop", error);
 					dialog.showErrorBox("Zerobyte tray failed to open", toMessage(error));
 				});
 		},
@@ -167,6 +169,10 @@ if (!app.requestSingleInstanceLock()) {
 
 	void app.whenReady().then(async () => {
 		try {
+			writeDesktopLog(
+				"desktop",
+				`Starting Zerobyte ${import.meta.env.VITE_APP_VERSION || app.getVersion()} on ${process.platform}/${process.arch}; Electron ${process.versions.electron}`,
+			);
 			if (process.platform !== "darwin") {
 				Menu.setApplicationMenu(null);
 			}
@@ -181,6 +187,7 @@ if (!app.requestSingleInstanceLock()) {
 			trayStatusTimer = setInterval(() => void refreshTrayStatus(), trayStatusPollMs);
 			await createWindow();
 		} catch (error) {
+			writeDesktopLog("desktop:startup", error);
 			if (trayStatusTimer) clearInterval(trayStatusTimer);
 			stopAccessingBookmarks?.();
 			stopAccessingBookmarks = null;
@@ -190,13 +197,22 @@ if (!app.requestSingleInstanceLock()) {
 	});
 }
 
-app.on("before-quit", () => {
+let shutdownStarted = false;
+app.on("before-quit", (event) => {
+	event.preventDefault();
+	if (shutdownStarted) return;
+	shutdownStarted = true;
 	isQuitting = true;
+
+	const finish = () => app.exit(0);
+	setTimeout(finish, 1_000);
+
 	if (trayStatusTimer) clearInterval(trayStatusTimer);
+	if (runtime) writeDesktopLog("desktop", "Stopping Zerobyte");
+
 	runtime?.stop();
-	runtime = null;
 	stopAccessingBookmarks?.();
-	stopAccessingBookmarks = null;
+	void closeDesktopLog().then(finish, finish);
 });
 
 app.on("window-all-closed", () => {});
@@ -208,6 +224,7 @@ ipcMain.handle("desktop:choose-folder", (event) => {
 
 	return chooseFolder();
 });
+
 ipcMain.handle("desktop:open-main-window", (event, appPath?: unknown) => {
 	if (!isTrustedDesktopSender(event.senderFrame?.url)) {
 		throw new Error("Invalid desktop IPC sender");
@@ -222,10 +239,12 @@ ipcMain.handle("desktop:open-main-window", (event, appPath?: unknown) => {
 
 	return createWindow(appPath);
 });
+
 ipcMain.on("desktop:quit", (event) => {
 	if (!isTrustedDesktopSender(event.senderFrame?.url)) return;
 	quitApp();
 });
+
 ipcMain.on("desktop:set-theme", (event, theme) => {
 	if (!isTrustedDesktopSender(event.senderFrame?.url)) return;
 	if (theme === "light" || theme === "dark") {

--- a/apps/desktop/electron/rotating-log.ts
+++ b/apps/desktop/electron/rotating-log.ts
@@ -1,0 +1,56 @@
+import { appendFile, mkdir, rename, stat } from "node:fs/promises";
+import path from "node:path";
+
+export class RotatingLog {
+	private pending = Promise.resolve();
+	private bufferedBytes = 0;
+	private closed = false;
+	private size: number | undefined;
+
+	constructor(
+		private readonly file: string,
+		private readonly maxBytes = 5 * 1024 * 1024,
+		private readonly maxBufferedBytes = 1024 * 1024,
+	) {}
+
+	write(line: string) {
+		if (this.closed) return;
+		const bytes = Buffer.byteLength(line);
+
+		if (this.bufferedBytes + bytes > this.maxBufferedBytes) return;
+
+		this.bufferedBytes += bytes;
+		this.pending = this.pending.then(async () => {
+			try {
+				await this.append(line);
+			} catch {
+				process.stderr.write("[zerobyte] Unable to write desktop log\n");
+			} finally {
+				this.bufferedBytes -= bytes;
+			}
+		});
+	}
+
+	private async append(line: string) {
+		if (this.size === undefined) {
+			await mkdir(path.dirname(this.file), { recursive: true, mode: 0o700 });
+			this.size = await stat(this.file).then(
+				(info) => info.size,
+				() => 0,
+			);
+		}
+
+		const bytes = Buffer.byteLength(line);
+		if (this.size > 0 && this.size + bytes > this.maxBytes) {
+			await rename(this.file, `${this.file}.1`);
+			this.size = 0;
+		}
+		await appendFile(this.file, line, { mode: 0o600 });
+		this.size += bytes;
+	}
+
+	close() {
+		this.closed = true;
+		return this.pending;
+	}
+}

--- a/packages/core/src/utils/__tests__/sanitize.test.ts
+++ b/packages/core/src/utils/__tests__/sanitize.test.ts
@@ -49,12 +49,6 @@ describe("sanitizeSensitiveData", () => {
 			expected: "request failed for https://alice:***@example.com/hook",
 			secret: "supersecret",
 		},
-		{
-			name: "space-delimited URL credential entry",
-			input: "https://dav.example.test/path operator dav-password",
-			expected: "https://dav.example.test/path operator ***",
-			secret: "dav-password",
-		},
 	])("redacts $name", ({ input, expected, secret }) => {
 		withNodeEnv("production", () => {
 			const sanitized = sanitizeSensitiveData(input);
@@ -62,6 +56,13 @@ describe("sanitizeSensitiveData", () => {
 			expect(sanitized).toBe(expected);
 			expect(sanitized).not.toContain(secret);
 		});
+	});
+
+	test.each([
+		"fetch https://example.test/data failed: ENOENT",
+		"Error: request https://example.test/data\n    at download (/app/download.ts:12:3)",
+	])("preserves URL-bearing diagnostics: %s", (input) => {
+		withNodeEnv("production", () => expect(sanitizeSensitiveData(input)).toBe(input));
 	});
 
 	test("does not redact in development", () => {

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -1,4 +1,5 @@
 export { safeJsonParse } from "./json.js";
+export { sanitizeSensitiveData } from "./sanitize.js";
 export { toErrorDetails, toMessage } from "./errors.js";
 export { hasPathListSeparator, isPathWithin, normalizeAbsolutePath } from "./path.js";
 export { findCommonAncestor } from "./common-ancestor.js";

--- a/packages/core/src/utils/sanitize.ts
+++ b/packages/core/src/utils/sanitize.ts
@@ -11,12 +11,5 @@ export const sanitizeSensitiveData = (text: string): string => {
 
 	sanitized = sanitized.replace(/\/\/([^:@\s]+):([^@\s]+)@/g, "//$1:***@");
 
-	sanitized = sanitized.replace(/(\S+)\s+(\S+)\s+(\S+)/g, (match, url, user, _pass) => {
-		if (url.startsWith("http://") || url.startsWith("https://")) {
-			return `${url} ${user} ***`;
-		}
-		return match;
-	});
-
 	return sanitized;
 };


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added persistent desktop logs with timestamps, source details, secret redaction, ANSI cleanup, size limits, and automatic rotation.
  - Added an “Open logs folder” option to the desktop tray menu.
  - Desktop runtime output and lifecycle events are now captured in the log files instead of the terminal.

- **Bug Fixes**
  - Improved shutdown handling to flush desktop logs reliably.
  - Added clearer error logging when volume directory listings fail.
  - Preserved URL-based diagnostic messages during sensitive-data sanitization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->