### PR TITLE
fix(desktop): return correct tree on windows

### DIFF
--- a/app/client/components/__tests__/desktop-ui.test.tsx
+++ b/app/client/components/__tests__/desktop-ui.test.tsx
@@ -1,0 +1,53 @@
+import { afterEach, expect, test, vi } from "vitest";
+import { fromPartial } from "@total-typescript/shoehorn";
+import { cleanup, render, screen, userEvent } from "~/test/test-utils";
+import { FolderSelector } from "../folder-selector";
+import { ThemeProvider } from "../theme-provider";
+
+afterEach(() => {
+	cleanup();
+	delete window.zerobyteDesktop;
+});
+
+test("uses the native folder picker inside Electron", async () => {
+	const chooseFolder = vi.fn().mockResolvedValue("/Users/test/Documents");
+	const onChange = vi.fn();
+	window.zerobyteDesktop = fromPartial({ chooseFolder });
+	render(<FolderSelector value="" onChange={onChange} />);
+	await userEvent.click(screen.getByRole("button", { name: "Choose" }));
+	expect(chooseFolder).toHaveBeenCalledTimes(1);
+	expect(onChange).toHaveBeenCalledWith("/Users/test/Documents");
+});
+
+test("offers the web folder browser without Electron", async () => {
+	render(
+		<FolderSelector
+			value=""
+			onChange={vi.fn()}
+			webBrowser={{
+				warning: { title: "Browse server folders", description: "Select a folder on the server." },
+			}}
+		/>,
+	);
+	await userEvent.click(screen.getByRole("button", { name: "Change" }));
+	expect(screen.getByRole("alertdialog").textContent).toContain("Browse server folders");
+	expect(screen.queryByRole("button", { name: "Choose" })).toBeNull();
+});
+
+test("synchronizes theme changes with Electron", () => {
+	const nativeSetTheme = vi.fn();
+	window.zerobyteDesktop = fromPartial({ setTheme: nativeSetTheme });
+	const setTheme = vi.fn();
+	const { rerender } = render(
+		<ThemeProvider theme="dark" setTheme={setTheme}>
+			content
+		</ThemeProvider>,
+	);
+	expect(nativeSetTheme).toHaveBeenLastCalledWith("dark");
+	rerender(
+		<ThemeProvider theme="light" setTheme={setTheme}>
+			content
+		</ThemeProvider>,
+	);
+	expect(nativeSetTheme).toHaveBeenLastCalledWith("light");
+});

--- a/app/client/components/file-browsers/__tests__/folder-access-error.test.tsx
+++ b/app/client/components/file-browsers/__tests__/folder-access-error.test.tsx
@@ -1,0 +1,164 @@
+import { afterEach, expect, test, vi } from "vitest";
+import { fromPartial } from "@total-typescript/shoehorn";
+import { cleanup, render, screen, userEvent, waitFor } from "~/test/test-utils";
+import { FolderAccessError } from "../folder-access-error";
+import { VolumeFileBrowser } from "../volume-file-browser";
+import { SnapshotTreeBrowser } from "../snapshot-tree-browser";
+import { HttpResponse, http, server } from "~/test/msw/server";
+
+afterEach(() => {
+	cleanup();
+	delete window.zerobyteDesktop;
+});
+
+test("offers Mac privacy settings for a denied folder", async () => {
+	const openPrivacySettings = vi.fn().mockResolvedValue(undefined);
+	render(
+		<FolderAccessError
+			message="Failed to list files: EPERM: operation not permitted, scandir Downloads"
+			openPrivacySettings={openPrivacySettings}
+		/>,
+	);
+	expect(screen.getByRole("alert").textContent).toContain("Access to this folder was denied.");
+	await userEvent.click(screen.getByRole("button", { name: "Open Privacy Settings" }));
+	expect(openPrivacySettings).toHaveBeenCalledTimes(1);
+});
+
+test("does not offer Mac settings without a recovery action", () => {
+	render(<FolderAccessError message="EACCES: permission denied" />);
+	expect(screen.getByRole("alert").textContent).toContain("Access to this folder was denied.");
+	expect(screen.queryByRole("button", { name: "Open Privacy Settings" })).toBeNull();
+});
+
+test("preserves unrelated errors without suggesting privacy settings", () => {
+	render(<FolderAccessError message="Directory not found" openPrivacySettings={vi.fn()} />);
+	expect(screen.getByRole("alert").textContent).toContain("Directory not found");
+	expect(screen.queryByRole("button")).toBeNull();
+});
+
+test("shows denied expansion beside the tree and allows a subsequent successful expansion", async () => {
+	window.zerobyteDesktop = fromPartial({ openPrivacySettings: vi.fn().mockResolvedValue(undefined) });
+	let denied = true;
+	server.use(
+		http.get("/api/v1/volumes/:shortId/files", ({ request }) => {
+			const path = new URL(request.url).searchParams.get("path");
+			if (path && denied)
+				return HttpResponse.json({ message: "EPERM: operation not permitted" }, { status: 500 });
+			return HttpResponse.json({
+				files: path
+					? [{ name: "example.txt", path: "/Downloads/example.txt", type: "file" }]
+					: [{ name: "Downloads", path: "/Downloads", type: "directory" }],
+				hasMore: false,
+			});
+		}),
+	);
+	render(<VolumeFileBrowser volumeId="test-volume" />);
+	await userEvent.click(await screen.findByRole("button", { name: "Expand folder" }));
+	expect(await screen.findByText("Access to this folder was denied.")).not.toBeNull();
+	expect(screen.getByText("Downloads")).not.toBeNull();
+	expect(screen.getByRole("button", { name: "Open Privacy Settings" })).not.toBeNull();
+	denied = false;
+	await userEvent.click(screen.getByRole("button", { name: "Collapse folder" }));
+	await userEvent.click(screen.getByRole("button", { name: "Expand folder" }));
+	expect(await screen.findByText("example.txt")).not.toBeNull();
+	expect(screen.queryByText("Access to this folder was denied.")).toBeNull();
+});
+
+test.each([true, false])("folder hover prefetch respects desktop=%s", async (desktop) => {
+	if (desktop) window.zerobyteDesktop = fromPartial({ chooseFolder: vi.fn() });
+	server.use(
+		http.get("/api/v1/volumes/:shortId/files", () =>
+			HttpResponse.json({
+				files: [{ name: "Downloads", path: "/Downloads", type: "directory" }],
+				hasMore: false,
+			}),
+		),
+	);
+	const { queryClient } = render(<VolumeFileBrowser volumeId="hover-volume" />);
+	const prefetch = vi.spyOn(queryClient, "prefetchQuery");
+	await userEvent.hover(await screen.findByRole("button", { name: "Downloads" }));
+	expect(prefetch).toHaveBeenCalledTimes(desktop ? 0 : 1);
+});
+
+test("keeps each denied folder's error when other folders are expanded", async () => {
+	server.use(
+		http.get("/api/v1/volumes/:shortId/files", ({ request }) => {
+			const path = new URL(request.url).searchParams.get("path");
+			if (path === "/Denied" || path === "/AlsoDenied") {
+				return HttpResponse.json({ message: "EACCES: permission denied" }, { status: 500 });
+			}
+			return HttpResponse.json({
+				files: path
+					? [{ name: "ok.txt", path: "/Other/ok.txt", type: "file" }]
+					: [
+							{ name: "Denied", path: "/Denied", type: "directory" },
+							{ name: "AlsoDenied", path: "/AlsoDenied", type: "directory" },
+							{ name: "Other", path: "/Other", type: "directory" },
+						],
+				hasMore: false,
+			});
+		}),
+	);
+	render(<VolumeFileBrowser volumeId="siblings" />);
+	await userEvent.click(await screen.findByTitle("Expand Denied"));
+	await screen.findByRole("alert");
+	await userEvent.click(screen.getByTitle("Expand AlsoDenied"));
+	await waitFor(() => expect(screen.getAllByRole("alert")).toHaveLength(2));
+	await userEvent.click(screen.getByTitle("Expand Other"));
+	await screen.findByText("ok.txt");
+	expect(screen.getAllByRole("alert")).toHaveLength(2);
+});
+
+test.each(["/", "/Folder"])("shows pagination failure for %s and clears it after retry", async (folderPath) => {
+	let denied = true;
+	server.use(
+		http.get("/api/v1/volumes/:shortId/files", ({ request }) => {
+			const query = new URL(request.url).searchParams;
+			if (folderPath !== "/" && !query.has("path")) {
+				return HttpResponse.json({
+					files: [{ name: "Folder", path: folderPath, type: "directory" }],
+					hasMore: false,
+				});
+			}
+			if (query.has("offset") && denied) {
+				return HttpResponse.json({ message: "EACCES: permission denied" }, { status: 500 });
+			}
+			const name = query.has("offset") ? "second.txt" : "first.txt";
+			return HttpResponse.json({
+				files: [{ name, path: `${folderPath === "/" ? "" : folderPath}/${name}`, type: "file" }],
+				offset: query.has("offset") ? 1 : 0,
+				limit: 1,
+				hasMore: !query.has("offset"),
+			});
+		}),
+	);
+	render(<VolumeFileBrowser volumeId="pagination" />);
+	if (folderPath !== "/") await userEvent.click(await screen.findByTitle("Expand Folder"));
+	await userEvent.click(await screen.findByRole("button", { name: "Load more files" }));
+	expect(await screen.findByRole("alert")).not.toBeNull();
+	expect(screen.getByText("first.txt")).not.toBeNull();
+	denied = false;
+	await userEvent.click(screen.getByRole("button", { name: "Load more files" }));
+	await screen.findByText("second.txt");
+	expect(screen.queryByRole("alert")).toBeNull();
+});
+
+test.each(["/", "/Folder"])(
+	"preserves snapshot errors at %s without offering local privacy settings",
+	async (failedPath) => {
+		window.zerobyteDesktop = fromPartial({ openPrivacySettings: vi.fn() });
+		const message = "EPERM: repository cache is not readable";
+		server.use(
+			http.get("/api/v1/repositories/:shortId/snapshots/:snapshotId/files", ({ request }) => {
+				if (new URL(request.url).searchParams.get("path") === failedPath) {
+					return HttpResponse.json({ message }, { status: 500 });
+				}
+				return HttpResponse.json({ files: [{ name: "Folder", path: "/Folder", type: "dir" }], hasMore: false });
+			}),
+		);
+		render(<SnapshotTreeBrowser repositoryId="repo" snapshotId="snapshot" />);
+		if (failedPath !== "/") await userEvent.click(await screen.findByTitle("Expand Folder"));
+		expect((await screen.findByRole("alert")).textContent).toBe(message);
+		expect(screen.queryByRole("button", { name: "Open Privacy Settings" })).toBeNull();
+	},
+);

--- a/app/client/components/file-browsers/file-browser.tsx
+++ b/app/client/components/file-browsers/file-browser.tsx
@@ -38,6 +38,8 @@ type FileBrowserProps = FileBrowserUiProps & {
 	isLoading: boolean;
 	isEmpty: boolean;
 	errorMessage?: string;
+	folderErrors: ReadonlyMap<string, string>;
+	renderError?: (message: string) => ReactNode;
 	fileArray: FileEntry[];
 	expandedFolders: Set<string>;
 	loadingFolders: Set<string>;
@@ -46,6 +48,12 @@ type FileBrowserProps = FileBrowserUiProps & {
 	onLoadMore: (folderPath: string) => void | Promise<void>;
 	getFolderPagination: (folderPath: string) => PaginationState;
 };
+
+const renderDefaultError = (message: string) => (
+	<p role="alert" className="text-destructive">
+		{message}
+	</p>
+);
 
 export const FileBrowser = (props: FileBrowserProps) => {
 	const {
@@ -74,6 +82,8 @@ export const FileBrowser = (props: FileBrowserProps) => {
 		isLoading,
 		isEmpty,
 		errorMessage,
+		folderErrors,
+		renderError = renderDefaultError,
 		fileArray,
 		expandedFolders,
 		loadingFolders,
@@ -98,7 +108,7 @@ export const FileBrowser = (props: FileBrowserProps) => {
 	} else if (errorMessage) {
 		body = (
 			<div className={cn("flex min-h-50 flex-col items-center justify-center p-6 text-center", stateClassName)}>
-				<p className="text-destructive">{errorMessage}</p>
+				{renderError(errorMessage)}
 			</div>
 		);
 	} else if (isEmpty) {
@@ -113,6 +123,10 @@ export const FileBrowser = (props: FileBrowserProps) => {
 		body = (
 			<FileTree
 				files={fileArray}
+				renderFolderError={(path) => {
+					const message = folderErrors.get(path);
+					return message ? renderError(message) : null;
+				}}
 				onFolderToggle={onFolderToggle}
 				onFolderHover={onFolderHover}
 				onLoadMore={onLoadMore}

--- a/app/client/components/file-browsers/folder-access-error.tsx
+++ b/app/client/components/file-browsers/folder-access-error.tsx
@@ -1,0 +1,29 @@
+import { toast } from "sonner";
+import { FileWarning } from "lucide-react";
+
+type Props = {
+	message: string;
+	openPrivacySettings?: () => Promise<void>;
+};
+
+export const FolderAccessError = ({ message, openPrivacySettings }: Props) => {
+	const denied = /\b(EPERM|EACCES)\b/.test(message);
+
+	return (
+		<div role="alert" className="flex flex-wrap items-center gap-x-2 gap-y-1 text-sm text-destructive">
+			<FileWarning className="size-4 shrink-0" aria-hidden="true" />
+			<span>{denied ? "Access to this folder was denied." : message}</span>
+			{denied && openPrivacySettings && (
+				<button
+					type="button"
+					className="cursor-pointer text-xs underline underline-offset-2 normal-case"
+					onClick={() =>
+						void openPrivacySettings().catch(() => toast.error("Could not open Privacy Settings"))
+					}
+				>
+					Open Privacy Settings
+				</button>
+			)}
+		</div>
+	);
+};

--- a/app/client/components/file-browsers/local-file-browser.tsx
+++ b/app/client/components/file-browsers/local-file-browser.tsx
@@ -5,6 +5,8 @@ import { useFileBrowser } from "~/client/hooks/use-file-browser";
 import { parseError } from "~/client/lib/errors";
 import { normalizeAbsolutePath } from "@zerobyte/core/utils";
 import { logger } from "~/client/lib/logger";
+import { useIsDesktop } from "~/client/hooks/use-is-desktop";
+import { FolderAccessError } from "./folder-access-error";
 
 type LocalFileBrowserProps = FileBrowserUiProps & {
 	initialPath?: string;
@@ -13,6 +15,7 @@ type LocalFileBrowserProps = FileBrowserUiProps & {
 
 export const LocalFileBrowser = ({ initialPath = "/", enabled = true, ...uiProps }: LocalFileBrowserProps) => {
 	const queryClient = useQueryClient();
+	const isDesktop = useIsDesktop();
 	const normalizedInitialPath = normalizeAbsolutePath(initialPath);
 
 	const { data, isLoading, error } = useQuery({
@@ -26,14 +29,25 @@ export const LocalFileBrowser = ({ initialPath = "/", enabled = true, ...uiProps
 		fetchFolder: async (path) => {
 			return await queryClient.ensureQueryData(browseFilesystemOptions({ query: { path } }));
 		},
-		prefetchFolder: (path) => {
-			void queryClient.prefetchQuery(browseFilesystemOptions({ query: { path } })).catch((e) => logger.error(e));
-		},
+		prefetchFolder: isDesktop
+			? undefined
+			: (path) => {
+					void queryClient
+						.prefetchQuery(browseFilesystemOptions({ query: { path } }))
+						.catch((e) => logger.error(e));
+				},
 	});
 
 	return (
 		<FileBrowser
 			{...uiProps}
+			folderErrors={fileBrowser.folderErrors}
+			renderError={(message) => (
+				<FolderAccessError
+					message={message}
+					openPrivacySettings={isDesktop ? window.zerobyteDesktop?.openPrivacySettings : undefined}
+				/>
+			)}
 			fileArray={fileBrowser.fileArray}
 			expandedFolders={fileBrowser.expandedFolders}
 			loadingFolders={fileBrowser.loadingFolders}

--- a/app/client/components/file-browsers/snapshot-tree-browser.tsx
+++ b/app/client/components/file-browsers/snapshot-tree-browser.tsx
@@ -139,6 +139,7 @@ export const SnapshotTreeBrowser = (props: SnapshotTreeBrowserProps) => {
 	return (
 		<FileBrowser
 			{...fileBrowserUiProps}
+			folderErrors={fileBrowser.folderErrors}
 			fileArray={fileBrowser.fileArray}
 			expandedFolders={fileBrowser.expandedFolders}
 			loadingFolders={fileBrowser.loadingFolders}

--- a/app/client/components/file-browsers/volume-file-browser.tsx
+++ b/app/client/components/file-browsers/volume-file-browser.tsx
@@ -4,6 +4,8 @@ import { FileBrowser, type FileBrowserUiProps } from "~/client/components/file-b
 import { useFileBrowser, type FetchFolderResult } from "~/client/hooks/use-file-browser";
 import { parseError } from "~/client/lib/errors";
 import { logger } from "~/client/lib/logger";
+import { useIsDesktop } from "~/client/hooks/use-is-desktop";
+import { FolderAccessError } from "./folder-access-error";
 
 type VolumeFileBrowserProps = FileBrowserUiProps & {
 	volumeId: string;
@@ -12,6 +14,7 @@ type VolumeFileBrowserProps = FileBrowserUiProps & {
 
 export const VolumeFileBrowser = ({ volumeId, enabled = true, ...uiProps }: VolumeFileBrowserProps) => {
 	const queryClient = useQueryClient();
+	const isDesktop = useIsDesktop();
 
 	const { data, isLoading, error } = useQuery({
 		...listFilesOptions({ path: { shortId: volumeId } }),
@@ -29,21 +32,30 @@ export const VolumeFileBrowser = ({ volumeId, enabled = true, ...uiProps }: Volu
 				}),
 			);
 		},
-		prefetchFolder: (path) => {
-			void queryClient
-				.prefetchQuery(
-					listFilesOptions({
-						path: { shortId: volumeId },
-						query: { path },
-					}),
-				)
-				.catch((e) => logger.error(e));
-		},
+		prefetchFolder: isDesktop
+			? undefined
+			: (path) => {
+					void queryClient
+						.prefetchQuery(
+							listFilesOptions({
+								path: { shortId: volumeId },
+								query: { path },
+							}),
+						)
+						.catch((e) => logger.error(e));
+				},
 	});
 
 	return (
 		<FileBrowser
 			{...uiProps}
+			folderErrors={fileBrowser.folderErrors}
+			renderError={(message) => (
+				<FolderAccessError
+					message={message}
+					openPrivacySettings={isDesktop ? window.zerobyteDesktop?.openPrivacySettings : undefined}
+				/>
+			)}
 			fileArray={fileBrowser.fileArray}
 			expandedFolders={fileBrowser.expandedFolders}
 			loadingFolders={fileBrowser.loadingFolders}

--- a/app/client/components/file-tree.tsx
+++ b/app/client/components/file-tree.tsx
@@ -39,6 +39,7 @@ interface PaginationState {
 
 interface Props {
 	files?: FileEntry[];
+	renderFolderError?: (folderPath: string) => ReactNode;
 	selectedFile?: string;
 	onFileSelect?: (filePath: string) => void;
 	onFolderToggle?: (folderPath: string, expanded: boolean) => void;
@@ -60,6 +61,7 @@ interface Props {
 export const FileTree = memo((props: Props) => {
 	const {
 		files = [],
+		renderFolderError,
 		onFileSelect,
 		selectedFile,
 		onFolderToggle,
@@ -291,6 +293,8 @@ export const FileTree = memo((props: Props) => {
 		return map;
 	}, [filteredFileList, getFolderPagination]);
 
+	const rootError = renderFolderError?.("/");
+
 	return (
 		<div className={cn("text-sm", className)}>
 			{filteredFileList.map((fileOrFolder, index) => {
@@ -336,6 +340,21 @@ export const FileTree = memo((props: Props) => {
 					}
 				}
 
+				const folderError = expandedFolders.has(fileOrFolder.fullPath)
+					? renderFolderError?.(fileOrFolder.fullPath)
+					: null;
+				if (folderError) {
+					elements.push(
+						<div
+							key={`error:${fileOrFolder.fullPath}`}
+							className="py-1.5 pr-2"
+							style={{ paddingLeft: 8 + (fileOrFolder.depth + 1) * NODE_PADDING_LEFT }}
+						>
+							{folderError}
+						</div>,
+					);
+				}
+
 				// Check if this is the last child of any folder with more files to load
 				for (const [folderPath, lastIndex] of folderPaginationMap.entries()) {
 					if (lastIndex === index) {
@@ -356,6 +375,7 @@ export const FileTree = memo((props: Props) => {
 
 				return elements;
 			})}
+			{rootError && <div className="px-2 py-1.5">{rootError}</div>}
 		</div>
 	);
 });

--- a/app/client/components/folder-selector.tsx
+++ b/app/client/components/folder-selector.tsx
@@ -13,7 +13,7 @@ import {
 	AlertDialogTitle,
 } from "./ui/alert-dialog";
 import { Button } from "./ui/button";
-import { useSystemInfo } from "~/client/hooks/use-system-info";
+import { useIsDesktop } from "~/client/hooks/use-is-desktop";
 
 type WebFolderBrowser = {
 	mode?: "inline" | "dialog";
@@ -43,8 +43,7 @@ export const FolderSelector = ({
 }: Props) => {
 	const [showBrowser, setShowBrowser] = useState(false);
 	const [showWarning, setShowWarning] = useState(false);
-	const { runtime } = useSystemInfo();
-	const isDesktop = runtime === "desktop";
+	const isDesktop = useIsDesktop();
 	const webBrowserMode = webBrowser?.mode ?? "inline";
 
 	const chooseDesktopFolder = async () => {

--- a/app/client/components/theme-provider.tsx
+++ b/app/client/components/theme-provider.tsx
@@ -1,4 +1,5 @@
 import { createContext, useContext, useEffect } from "react";
+import { useIsDesktop } from "~/client/hooks/use-is-desktop";
 
 export type Theme = "light" | "dark";
 
@@ -13,9 +14,10 @@ export const THEME_COOKIE_NAME = "theme";
 export const DEFAULT_THEME: Theme = "dark";
 
 export function ThemeProvider({ children, theme, setTheme }: ThemeContextValue & { children: React.ReactNode }) {
+	const isDesktop = useIsDesktop();
 	useEffect(() => {
-		window.zerobyteDesktop?.setTheme(theme);
-	}, [theme]);
+		if (isDesktop) window.zerobyteDesktop?.setTheme(theme);
+	}, [isDesktop, theme]);
 
 	return <ThemeContext value={{ theme, setTheme }}>{children}</ThemeContext>;
 }

--- a/app/client/hooks/use-file-browser.ts
+++ b/app/client/hooks/use-file-browser.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
+import { parseError } from "~/client/lib/errors";
 import { logger } from "~/client/lib/logger";
 import type { FileEntry } from "../components/file-tree";
 
@@ -36,6 +37,7 @@ type FolderPaginationState = {
 
 export const useFileBrowser = (props: UseFileBrowserOptions) => {
 	const { initialData, isLoading, fetchFolder, prefetchFolder, pathTransform, rootPath = "/" } = props;
+	const [folderErrors, setFolderErrors] = useState<ReadonlyMap<string, string>>(new Map());
 	const [expandedFolders, setExpandedFolders] = useState<Set<string>>(new Set());
 	const [fetchedFolders, setFetchedFolders] = useState<Set<string>>(new Set([rootPath]));
 	const [loadingFolders, setLoadingFolders] = useState<Set<string>>(new Set());
@@ -44,6 +46,15 @@ export const useFileBrowser = (props: UseFileBrowserOptions) => {
 
 	const stripPath = pathTransform?.strip;
 	const addPath = pathTransform?.add;
+
+	const setFolderError = useCallback((path: string, message?: string) => {
+		setFolderErrors((prev) => {
+			const next = new Map(prev);
+			if (message === undefined) next.delete(path);
+			else next.set(path, message);
+			return next;
+		});
+	}, []);
 
 	useEffect(() => {
 		if (initialData?.files) {
@@ -100,6 +111,7 @@ export const useFileBrowser = (props: UseFileBrowserOptions) => {
 
 			if (!expanded || fetchedFolders.has(folderPath)) return;
 
+			setFolderError(folderPath);
 			setLoadingFolders((prev) => new Set(prev).add(folderPath));
 
 			try {
@@ -143,6 +155,7 @@ export const useFileBrowser = (props: UseFileBrowserOptions) => {
 				setFetchedFolders((prev) => new Set(prev).add(folderPath));
 			} catch (error) {
 				logger.error("Failed to fetch folder contents:", error);
+				setFolderError(folderPath, parseError(error)?.message ?? "Failed to read folder");
 			} finally {
 				setLoadingFolders((prev) => {
 					const next = new Set(prev);
@@ -151,7 +164,7 @@ export const useFileBrowser = (props: UseFileBrowserOptions) => {
 				});
 			}
 		},
-		[fetchedFolders, fetchFolder, stripPath, addPath],
+		[fetchedFolders, fetchFolder, stripPath, addPath, setFolderError],
 	);
 
 	const handleLoadMore = useCallback(
@@ -161,6 +174,7 @@ export const useFileBrowser = (props: UseFileBrowserOptions) => {
 				return;
 			}
 
+			setFolderError(folderPath);
 			setFolderPagination((prev) => {
 				const next = new Map(prev);
 				next.set(folderPath, { ...pagination, isLoadingMore: true });
@@ -197,6 +211,7 @@ export const useFileBrowser = (props: UseFileBrowserOptions) => {
 				}
 			} catch (error) {
 				logger.error("Failed to load more files:", error);
+				setFolderError(folderPath, parseError(error)?.message ?? "Failed to read folder");
 				setFolderPagination((prev) => {
 					const next = new Map(prev);
 					next.set(folderPath, { ...pagination, isLoadingMore: false });
@@ -204,7 +219,7 @@ export const useFileBrowser = (props: UseFileBrowserOptions) => {
 				});
 			}
 		},
-		[folderPagination, fetchFolder, stripPath, addPath],
+		[folderPagination, fetchFolder, stripPath, addPath, setFolderError],
 	);
 
 	const handleFolderHover = useCallback(
@@ -225,6 +240,7 @@ export const useFileBrowser = (props: UseFileBrowserOptions) => {
 	);
 
 	return {
+		folderErrors,
 		fileArray,
 		expandedFolders,
 		loadingFolders,

--- a/app/client/hooks/use-is-desktop.ts
+++ b/app/client/hooks/use-is-desktop.ts
@@ -1,0 +1,7 @@
+import { useSyncExternalStore } from "react";
+
+const subscribe = () => () => {};
+const getSnapshot = () => Boolean(window.zerobyteDesktop);
+const getServerSnapshot = () => false;
+
+export const useIsDesktop = () => useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);

--- a/app/client/types/desktop.d.ts
+++ b/app/client/types/desktop.d.ts
@@ -1,4 +1,5 @@
 type ZerobyteDesktopApi = {
+	openPrivacySettings?: () => Promise<void>;
 	chooseFolder: () => Promise<string | null>;
 	openMainWindow: (path?: string) => Promise<void>;
 	quit: () => void;

--- a/app/lib/__tests__/api-query-hydration.test.ts
+++ b/app/lib/__tests__/api-query-hydration.test.ts
@@ -5,47 +5,55 @@ import { createClient } from "~/client/api-client/client";
 import { getSystemInfoOptions, getSystemInfoQueryKey } from "~/client/api-client/@tanstack/react-query.gen";
 import { createRequestClient, runWithRequestClient } from "~/lib/request-client";
 
-test("reuses SSR system info after hydration while requests retain their own URL and cookies", async () => {
-	const originalConfig = client.getConfig();
-	const baseUrl = "https://zerobyte.example";
-	const serverCache = new QueryClient();
-	const browserCache = new QueryClient();
-	const systemInfo = {
-		runtime: "desktop",
-		capabilities: { rclone: false, sysAdmin: false, volumeBackends: ["directory"], repositoryBackends: ["local"] },
-	};
-	const requests: Request[] = [];
-	const fetch = vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
-		const request = new Request(input, init);
-		requests.push(request);
-		return Response.json(systemInfo);
-	});
-	const serverClient = createRequestClient({ baseUrl, headers: { cookie: "session=ssr" } }, "http://127.0.0.1:54321");
+test.each(["http://127.0.0.1:54321", "https://127.0.0.1:54321"])(
+	"reuses SSR system info after hydration with transport %s",
+	async (internalOrigin) => {
+		const originalConfig = client.getConfig();
+		const baseUrl = "https://zerobyte.example";
+		const serverCache = new QueryClient();
+		const browserCache = new QueryClient();
+		const systemInfo = {
+			runtime: "desktop",
+			capabilities: {
+				rclone: false,
+				sysAdmin: false,
+				volumeBackends: ["directory"],
+				repositoryBackends: ["local"],
+			},
+		};
+		const requests: Request[] = [];
+		const fetch = vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+			const request = new Request(input, init);
+			requests.push(request);
+			return Response.json(systemInfo);
+		});
+		const serverClient = createRequestClient({ baseUrl, headers: { cookie: "session=ssr" } }, internalOrigin);
 
-	try {
-		client.setConfig({ baseUrl });
-		await runWithRequestClient(serverClient, () => serverCache.fetchQuery(getSystemInfoOptions()));
-		const serializedCache = JSON.stringify(dehydrate(serverCache));
-		hydrate(browserCache, JSON.parse(serializedCache));
+		try {
+			client.setConfig({ baseUrl });
+			await runWithRequestClient(serverClient, () => serverCache.fetchQuery(getSystemInfoOptions()));
+			const serializedCache = JSON.stringify(dehydrate(serverCache));
+			hydrate(browserCache, JSON.parse(serializedCache));
 
-		expect(browserCache.getQueryData(getSystemInfoQueryKey())).toEqual(systemInfo);
-		expect(requests[0]?.url).toBe("http://127.0.0.1:54321/api/v1/system/info");
-		expect(requests[0]?.headers.get("cookie")).toBe("session=ssr");
-		expect(serializedCache).not.toContain("127.0.0.1");
-		expect(serializedCache).not.toContain("session=ssr");
+			expect(browserCache.getQueryData(getSystemInfoQueryKey())).toEqual(systemInfo);
+			expect(requests[0]?.url).toBe(`${internalOrigin}/api/v1/system/info`);
+			expect(requests[0]?.headers.get("cookie")).toBe("session=ssr");
+			expect(serializedCache).not.toContain("127.0.0.1");
+			expect(serializedCache).not.toContain("session=ssr");
 
-		await browserCache.ensureQueryData(getSystemInfoOptions());
-		expect(fetch).toHaveBeenCalledTimes(1);
-		await browserCache.fetchQuery(getSystemInfoOptions());
-		expect(requests[1]?.url).toBe("https://zerobyte.example/api/v1/system/info");
-		expect(requests[1]?.headers.has("cookie")).toBe(false);
-	} finally {
-		fetch.mockRestore();
-		client.setConfig(originalConfig);
-		serverCache.clear();
-		browserCache.clear();
-	}
-});
+			await browserCache.ensureQueryData(getSystemInfoOptions());
+			expect(fetch).toHaveBeenCalledTimes(1);
+			await browserCache.fetchQuery(getSystemInfoOptions());
+			expect(requests[1]?.url).toBe("https://zerobyte.example/api/v1/system/info");
+			expect(requests[1]?.headers.has("cookie")).toBe(false);
+		} finally {
+			fetch.mockRestore();
+			client.setConfig(originalConfig);
+			serverCache.clear();
+			browserCache.clear();
+		}
+	},
+);
 
 test("keeps explicitly selected API origins in separate caches", () => {
 	const cache = new QueryClient();

--- a/app/middleware/__tests__/api-client.test.ts
+++ b/app/middleware/__tests__/api-client.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, expect, test, vi } from "vitest";
+import { getRequestClient } from "~/lib/request-client";
+
+const { register, config } = vi.hoisted(() => ({
+	register: vi.fn<(handler: (context: { next: () => Promise<void> }) => Promise<void>) => void>(),
+	config: { runtime: "desktop", port: 54321 },
+}));
+
+vi.mock("@tanstack/react-start", () => ({
+	createMiddleware: () => ({ server: register }),
+}));
+vi.mock("@tanstack/react-start/server", () => ({
+	getRequestUrl: () => new URL("https://127.0.0.1:54321/volumes"),
+	getRequestHeaders: () => new Headers({ cookie: "session=desktop" }),
+}));
+vi.mock("../../server/core/config", () => ({ config }));
+
+await import("../api-client");
+const run = register.mock.calls[0][0];
+
+afterEach(() => {
+	vi.restoreAllMocks();
+	vi.unstubAllEnvs();
+	config.runtime = "desktop";
+});
+
+test("desktop SSR uses HTTPS with the launch certificate and preserves the session cookie", async () => {
+	vi.stubEnv("NITRO_SSL_CERT", "launch-certificate");
+	const network = vi.spyOn(globalThis, "fetch").mockResolvedValue(Response.json({ ok: true }));
+	await run({
+		next: async () => {
+			await getRequestClient().get({ url: "/api/v1/system/info", throwOnError: true });
+		},
+	});
+	const [input, options] = network.mock.calls[0];
+	const request = new Request(input);
+	expect(request.url).toBe("https://127.0.0.1:54321/api/v1/system/info");
+	expect(request.headers.get("cookie")).toBe("session=desktop");
+	expect(options).toEqual({ redirect: "error", tls: { ca: "launch-certificate" } });
+});
+
+test("desktop SSR fails before sending credentials when its certificate is missing", async () => {
+	vi.stubEnv("NITRO_SSL_CERT", "");
+	const network = vi.spyOn(globalThis, "fetch");
+	await expect(
+		run({
+			next: async () => {
+				await getRequestClient().get({ url: "/api/v1/system/info", throwOnError: true });
+			},
+		}),
+	).rejects.toThrow("Desktop SSR is missing its TLS certificate");
+	expect(network).not.toHaveBeenCalled();
+});
+
+test("server deployment continues to use internal HTTP", async () => {
+	config.runtime = "server";
+	const network = vi.spyOn(globalThis, "fetch").mockResolvedValue(Response.json({ ok: true }));
+	await run({
+		next: async () => {
+			await getRequestClient().get({ url: "/api/v1/system/info", throwOnError: true });
+		},
+	});
+	expect(new Request(network.mock.calls[0][0]).url).toBe("http://127.0.0.1:54321/api/v1/system/info");
+});
+
+test("explicit external API requests use normal certificate trust", async () => {
+	const network = vi.spyOn(globalThis, "fetch").mockResolvedValue(Response.json({ ok: true }));
+	await run({
+		next: async () => {
+			await getRequestClient().get({ baseUrl: "https://other.example", url: "/api/test", throwOnError: true });
+		},
+	});
+	expect(new Request(network.mock.calls[0][0]).url).toBe("https://other.example/api/test");
+	expect(network.mock.calls[0][1]).toBeUndefined();
+});

--- a/app/middleware/api-client.ts
+++ b/app/middleware/api-client.ts
@@ -5,12 +5,26 @@ import { config } from "../server/core/config";
 
 export const apiClientMiddleware = createMiddleware().server(async ({ next }) => {
 	const baseUrl = getRequestUrl({ xForwardedHost: true }).origin;
-	const internalOrigin = `http://127.0.0.1:${config.port}`;
+	const desktop = config.runtime === "desktop";
+	const internalOrigin = `${desktop ? "https" : "http"}://127.0.0.1:${config.port}`;
 	const cookie = getRequestHeaders().get("cookie") ?? "";
+
+	function fetchDesktop(input: RequestInfo | URL, init?: RequestInit) {
+		const request = new Request(input, init);
+		if (new URL(request.url).origin !== internalOrigin) return fetch(request);
+
+		const certificate = process.env.NITRO_SSL_CERT;
+		if (!certificate) throw new Error("Desktop SSR is missing its TLS certificate");
+
+		return fetch(request, { redirect: "error", tls: { ca: certificate } });
+	}
+	fetchDesktop.preconnect = fetch.preconnect;
+
 	const client = createRequestClient(
 		{
 			baseUrl,
 			headers: { cookie },
+			fetch: desktop ? fetchDesktop : fetch,
 		},
 		internalOrigin,
 	);

--- a/apps/agent/src/volume-host/__tests__/operations.test.ts
+++ b/apps/agent/src/volume-host/__tests__/operations.test.ts
@@ -6,10 +6,15 @@ import { afterEach, expect, test, vi } from "vitest";
 import { logger } from "@zerobyte/core/node";
 import { listVolumeFiles } from "../operations";
 
+vi.mock("node:fs/promises", async (importOriginal) => ({
+	...(await importOriginal<typeof fs>()),
+}));
+
 let tempRoot: string | undefined;
 
 afterEach(async () => {
 	vi.restoreAllMocks();
+	vi.unstubAllGlobals();
 	if (tempRoot) {
 		await fs.rm(tempRoot, { recursive: true, force: true });
 		tempRoot = undefined;
@@ -73,4 +78,32 @@ test("listVolumeFiles reports missing directories consistently", async () => {
 		error: expect.stringContaining("ENOENT"),
 		code: "ENOENT",
 	});
+});
+
+test("listVolumeFiles returns slash-separated paths when expanding nested folders", async () => {
+	const volume = await createDirectoryVolume();
+	await fs.mkdir(path.join(tempRoot!, "Default", "AppData", "Local"), { recursive: true });
+	await fs.writeFile(path.join(tempRoot!, "Default", "AppData", "Local", "example.txt"), "hello");
+
+	const folders = await listVolumeFiles(volume, "/Default/AppData");
+	expect(folders.files).toEqual([
+		expect.objectContaining({ name: "Local", path: "/Default/AppData/Local", type: "directory" }),
+	]);
+	const files = await listVolumeFiles(volume, folders.files[0]!.path);
+	expect(files.files).toEqual([
+		expect.objectContaining({ name: "example.txt", path: "/Default/AppData/Local/example.txt", type: "file" }),
+	]);
+});
+
+test("listVolumeFiles restores the separator when Windows realpath returns a bare drive", async () => {
+	const volume = await createDirectoryVolume();
+	volume.config = { backend: "directory", path: "C:\\" };
+	vi.stubGlobal("process", { ...process, platform: "win32" });
+	const resolve = vi.spyOn(fs, "realpath").mockResolvedValue("C:");
+	const read = vi.spyOn(fs, "readdir").mockResolvedValue([]);
+
+	const result = await listVolumeFiles(volume);
+	expect(resolve).toHaveBeenCalledWith("C:\\");
+	expect(read).toHaveBeenCalledWith("C:\\", { withFileTypes: true });
+	expect(result.files).toEqual([]);
 });

--- a/apps/agent/src/volume-host/operations.ts
+++ b/apps/agent/src/volume-host/operations.ts
@@ -10,6 +10,11 @@ import { createVolumeBackend, getVolumePath, isNodeJSErrnoException } from ".";
 const DEFAULT_PAGE_SIZE = 500;
 const MAX_PAGE_SIZE = 500;
 
+const realpath = async (value: string) => {
+	const resolved = await fs.realpath(value);
+	return process.platform === "win32" && /^[a-z]:$/i.test(resolved) ? `${resolved}\\` : resolved;
+};
+
 export const listVolumeFiles = async (
 	volume: AgentVolume,
 	subPath?: string,
@@ -33,8 +38,8 @@ export const listVolumeFiles = async (
 	const startOffset = Math.max(offset, 0);
 
 	try {
-		const realVolumeRoot = await fs.realpath(volumePath);
-		const realRequestedPath = await fs.realpath(requestedPath);
+		const realVolumeRoot = await realpath(volumePath);
+		const realRequestedPath = await realpath(requestedPath);
 		const relative = path.relative(realVolumeRoot, realRequestedPath);
 
 		if (relative === ".." || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) {
@@ -67,7 +72,7 @@ export const listVolumeFiles = async (
 
 						return {
 							name: dirent.name,
-							path: `/${relativePath}`,
+							path: `/${relativePath.split(path.sep).join("/")}`,
 							type: dirent.isDirectory() ? ("directory" as const) : ("file" as const),
 							size: dirent.isFile() ? stats.size : undefined,
 							modifiedAt: stats.mtimeMs,

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -6,6 +6,7 @@ import {
 	Menu,
 	nativeTheme,
 	session,
+	shell,
 	type OpenDialogOptions,
 	type Tray,
 } from "electron";
@@ -250,4 +251,10 @@ ipcMain.on("desktop:set-theme", (event, theme) => {
 	if (theme === "light" || theme === "dark") {
 		nativeTheme.themeSource = theme;
 	}
+});
+
+ipcMain.handle("desktop:open-privacy-settings", async (event) => {
+	if (!isTrustedDesktopSender(event.senderFrame?.url)) throw new Error("Invalid desktop IPC sender");
+	if (process.platform !== "darwin") return;
+	await shell.openExternal("x-apple.systempreferences:com.apple.preference.security?Privacy_FilesAndFolders");
 });

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -1,6 +1,8 @@
 import { contextBridge, ipcRenderer } from "electron";
 
 contextBridge.exposeInMainWorld("zerobyteDesktop", {
+	openPrivacySettings:
+		process.platform === "darwin" ? () => ipcRenderer.invoke("desktop:open-privacy-settings") : undefined,
 	chooseFolder: () => ipcRenderer.invoke("desktop:choose-folder"),
 	openMainWindow: (path?: string) => ipcRenderer.invoke("desktop:open-main-window", path),
 	quit: () => ipcRenderer.send("desktop:quit"),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added clearer folder-access error messages within file browsers.
  - Added an **Open Privacy Settings** action on macOS when folder permissions are denied.
  - Displayed errors for individual folders and pagination requests, with errors cleared after successful retries.

- **Bug Fixes**
  - Improved desktop folder browsing by avoiding unsupported prefetch behavior.
  - Improved cross-platform folder path handling, including Windows drive roots.
  - Desktop internal requests now use secure HTTPS communication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->